### PR TITLE
Pools gas optimization 2

### DIFF
--- a/contracts/RubiconMarket.sol
+++ b/contracts/RubiconMarket.sol
@@ -620,6 +620,7 @@ contract RubiconMarket is MatchingEvents, ExpiringMarket, DSNote {
     ) public override returns (uint256) {
         require(!locked, "Reentrancy attempt");
 
+
             function(uint256, ERC20, uint256, ERC20) returns (uint256) fn
          = matchingEnabled ? _offeru : super.offer;
         return fn(pay_amt, pay_gem, buy_amt, buy_gem);

--- a/contracts/peripheral_contracts/DaiWithFaucet.sol
+++ b/contracts/peripheral_contracts/DaiWithFaucet.sol
@@ -91,7 +91,7 @@ contract DaiWithFaucet is LibNote, ERC20 {
         address admin,
         string memory _name,
         string memory _symbol
-    ) public ERC20(_name, _symbol) {
+    ) ERC20(_name, _symbol) {
         wards[msg.sender] = 1;
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(

--- a/contracts/peripheral_contracts/EquityToken.sol
+++ b/contracts/peripheral_contracts/EquityToken.sol
@@ -16,7 +16,7 @@ contract EquityToken is ERC20 {
         uint256 initialSupply,
         string memory _name,
         string memory _symbol
-    ) public ERC20(_name, _symbol) {
+    ) ERC20(_name, _symbol) {
         _mint(admin, initialSupply);
     }
 }

--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -335,141 +335,54 @@ contract BathPair {
     }
 
     function cancelPartialFills() internal {
-        // ** Assume that any partialFill or totalFill resulted in yield **
+        uint timeDelay = BathHouse(bathHouse).timeDelay();
         for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-            // If neither is zero...
-            if (
-                outstandingPairIDs[x][0] != 0 && outstandingPairIDs[x][1] != 0
-            ) {
-                order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
-                order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
+                if (
+                    outstandingPairIDs[x][2] <
+                    (block.timestamp - timeDelay)
+                ) {
+                    // If both filled fully
+                    // if (outstandingPairIDs[x][0] != 0 && outstandingPairIDs[x][1] != 0) {
+                    order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
+                    order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
+                    BathToken(bathQuoteAddress).cancel(
+                        outstandingPairIDs[x][1]
+                    );
+                    BathToken(bathAssetAddress).cancel(
+                        outstandingPairIDs[x][0]
+                    );
 
-                if (
-                    (offer1.pay_amt == 0 &&
-                        offer1.pay_gem == ERC20(0) &&
-                        offer1.buy_amt == 0 &&
-                        offer1.buy_gem == ERC20(0)) &&
-                    (offer2.pay_amt != 0 &&
-                        offer2.pay_gem != ERC20(0) &&
-                        offer2.buy_amt != 0 &&
-                        offer2.buy_gem != ERC20(0))
-                ) {
-                    // cancel offer2 and delete from outstandingPairsIDs as both orders are gone.
-                    BathToken(bathQuoteAddress).cancel(
-                        outstandingPairIDs[x][1]
-                    );
-                    // true if quote fills -> asset yield
-                    logFill(outstandingPairIDs[x][0], true);
-                    removeElement(x);
-                    continue;
-                } else if (
-                    (offer1.pay_amt != 0 &&
-                        offer1.pay_gem != ERC20(0) &&
-                        offer1.buy_amt != 0 &&
-                        offer1.pay_gem != ERC20(0)) &&
-                    (offer2.pay_amt == 0 &&
-                        offer2.pay_gem == ERC20(0) &&
-                        offer2.buy_amt == 0 &&
-                        offer2.buy_gem == ERC20(0))
-                ) {
-                    BathToken(bathAssetAddress).cancel(
-                        outstandingPairIDs[x][0]
-                    );
-                    logFill(outstandingPairIDs[x][1], false);
-                    removeElement(x);
-                    continue;
-                } else if (
-                    (offer1.pay_amt != 0 &&
-                        offer1.pay_gem != ERC20(0) &&
-                        offer1.buy_amt != 0 &&
-                        offer1.pay_gem != ERC20(0)) &&
-                    (offer2.pay_amt != 0 &&
-                        offer2.pay_gem != ERC20(0) &&
-                        offer2.buy_amt != 0 &&
-                        offer2.buy_gem != ERC20(0))
-                ) {
-                    // delete the offer if it is too old - this forces the expungement of static orders
-                    if (
-                        outstandingPairIDs[x][2] <
-                        (block.timestamp - BathHouse(bathHouse).timeDelay())
-                    ) {
-                        // Cancel due to outstanding for too long
-                        BathToken(bathAssetAddress).cancel(
-                            outstandingPairIDs[x][0]
-                        );
-                        BathToken(bathQuoteAddress).cancel(
-                            outstandingPairIDs[x][1]
-                        );
-                        removeElement(x);
-                        continue;
-                    } else {
-                        continue;
+                    // If Yield: 
+                    // getOfferInfo will make no yield recognizable on an empty offer
+                    if (offer1.pay_amt == 0 && offer2.pay_amt == 0) {
+                        logFill(outstandingPairIDs[x][0], true);
+                        logFill(outstandingPairIDs[x][1], false);
+                    } else if (offer1.pay_amt == 0) {
+                        logFill(outstandingPairIDs[x][0], true);
+                    } else if (offer1.pay_amt == 0) {
+                        logFill(outstandingPairIDs[x][1], false); 
                     }
-                }
-            }
-            // just ask
-            else if (outstandingPairIDs[x][0] != 0) {
-                order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
-                // fill check
-                if (
-                    offer1.pay_amt == 0 &&
-                    offer1.pay_gem == ERC20(0) &&
-                    offer1.buy_amt == 0 &&
-                    offer1.pay_gem == ERC20(0)
-                ) {
-                    logFill(outstandingPairIDs[x][0], true);
+
                     removeElement(x);
-                    continue;
-                }
-                // time check
-                if (
-                    outstandingPairIDs[x][2] <
-                    (block.timestamp - BathHouse(bathHouse).timeDelay())
-                ) {
-                    BathToken(bathAssetAddress).cancel(
-                        outstandingPairIDs[x][0]
-                    );
-                    removeElement(x);
-                    continue;
-                }
-            } else {
-                order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
-                // fill check
-                if (
-                    offer2.pay_amt == 0 &&
-                    offer2.pay_gem == ERC20(0) &&
-                    offer2.buy_amt == 0 &&
-                    offer2.pay_gem == ERC20(0)
-                ) {
-                    logFill(outstandingPairIDs[x][1], false);
-                    removeElement(x);
-                    continue;
-                }
-                // time check
-                if (
-                    outstandingPairIDs[x][2] <
-                    (block.timestamp - BathHouse(bathHouse).timeDelay())
-                ) {
-                    BathToken(bathQuoteAddress).cancel(
-                        outstandingPairIDs[x][1]
-                    );
-                    removeElement(x);
-                    continue;
-                }
-            }
+                    }
         }
     }
 
     // Get offer info from Rubicon Market
     function getOfferInfo(uint256 id) internal view returns (order memory) {
-        (
+        if (id == 0) {
+            order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
+            return offerInfo;
+        } else {        
+            (
             uint256 ask_amt,
             ERC20 ask_gem,
             uint256 bid_amt,
             ERC20 bid_gem
         ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
         order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
-        return offerInfo;
+        return offerInfo;}
+
     }
 
     function getOutstandingPairCount() external view returns (uint256) {

--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -344,16 +344,28 @@ contract BathPair {
                 order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
 
                 // If Yield:
-                // getOfferInfo will make no yield recognizable on an empty offer
+                // getOfferInfo will make no yield recognizable on an empty offer by assigning pay_amt = 420;
                 if (offer1.pay_amt == 0 && offer2.pay_amt == 0) {
                     //both non-zero
                     logFill(outstandingPairIDs[x][0], true);
                     logFill(outstandingPairIDs[x][1], false);
+                    BathToken(bathAssetAddress).removeFilledTrade(
+                        outstandingPairIDs[x][0]
+                    );
+                    BathToken(bathQuoteAddress).removeFilledTrade(
+                        outstandingPairIDs[x][1]
+                    );
                 } else if (offer1.pay_amt == 0) {
                     // ask is non-zerp
                     logFill(outstandingPairIDs[x][0], true);
+                                        BathToken(bathAssetAddress).removeFilledTrade(
+                        outstandingPairIDs[x][0]
+                    );
                 } else if (offer1.pay_amt == 0) {
                     logFill(outstandingPairIDs[x][1], false);
+                                        BathToken(bathQuoteAddress).removeFilledTrade(
+                        outstandingPairIDs[x][1]
+                    );
                 }
 
                 // If non-zero real order, cancel
@@ -518,7 +530,7 @@ contract BathPair {
         require(
             outstandingPairIDs.length <
                 BathHouse(bathHouse).maxOutstandingPairCount(),
-            "too many outstanding pairs"
+            "too many outstanding pairs, please call bathScrub() first"
         );
 
         // 1. Enforce that a spread exists and that the ask price > best bid price && bid price < best ask price

--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -345,28 +345,39 @@ contract BathPair {
                     // if (outstandingPairIDs[x][0] != 0 && outstandingPairIDs[x][1] != 0) {
                     order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
                     order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
-                    BathToken(bathQuoteAddress).cancel(
-                        outstandingPairIDs[x][1]
-                    );
-                    BathToken(bathAssetAddress).cancel(
-                        outstandingPairIDs[x][0]
-                    );
 
                     // If Yield: 
                     // getOfferInfo will make no yield recognizable on an empty offer
-                    if (offer1.pay_amt == 0 && offer2.pay_amt == 0) {
+                    if (offer1.pay_amt == 0 && offer2.pay_amt == 0) { //both non-zero
                         logFill(outstandingPairIDs[x][0], true);
                         logFill(outstandingPairIDs[x][1], false);
+
                     } else if (offer1.pay_amt == 0) {
+                        // ask is non-zerp
                         logFill(outstandingPairIDs[x][0], true);
                     } else if (offer1.pay_amt == 0) {
                         logFill(outstandingPairIDs[x][1], false); 
                     }
 
-                    removeElement(x);
+                    // If non-zero real order, cancel
+                    if (offer1.pay_amt != 0 && offer1.pay_amt != 420) {
+                        BathToken(bathAssetAddress).cancel(
+                         outstandingPairIDs[x][0]
+                        );
                     }
+                    if (offer2.pay_amt != 0 && offer2.pay_amt != 420) {
+                        BathToken(bathQuoteAddress).cancel(
+                        outstandingPairIDs[x][1]
+                    );
+                    }
+                    removeElement(x);
+                    x--;
+              }
         }
     }
+                        //   cancel both
+
+
 
     // Get offer info from Rubicon Market
     function getOfferInfo(uint256 id) internal view returns (order memory) {

--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -335,65 +335,61 @@ contract BathPair {
     }
 
     function cancelPartialFills() internal {
-        uint timeDelay = BathHouse(bathHouse).timeDelay();
+        uint256 timeDelay = BathHouse(bathHouse).timeDelay();
         for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-                if (
-                    outstandingPairIDs[x][2] <
-                    (block.timestamp - timeDelay)
-                ) {
-                    // If both filled fully
-                    // if (outstandingPairIDs[x][0] != 0 && outstandingPairIDs[x][1] != 0) {
-                    order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
-                    order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
+            if (outstandingPairIDs[x][2] < (block.timestamp - timeDelay)) {
+                // If both filled fully
+                // if (outstandingPairIDs[x][0] != 0 && outstandingPairIDs[x][1] != 0) {
+                order memory offer1 = getOfferInfo(outstandingPairIDs[x][0]);
+                order memory offer2 = getOfferInfo(outstandingPairIDs[x][1]);
 
-                    // If Yield: 
-                    // getOfferInfo will make no yield recognizable on an empty offer
-                    if (offer1.pay_amt == 0 && offer2.pay_amt == 0) { //both non-zero
-                        logFill(outstandingPairIDs[x][0], true);
-                        logFill(outstandingPairIDs[x][1], false);
+                // If Yield:
+                // getOfferInfo will make no yield recognizable on an empty offer
+                if (offer1.pay_amt == 0 && offer2.pay_amt == 0) {
+                    //both non-zero
+                    logFill(outstandingPairIDs[x][0], true);
+                    logFill(outstandingPairIDs[x][1], false);
+                } else if (offer1.pay_amt == 0) {
+                    // ask is non-zerp
+                    logFill(outstandingPairIDs[x][0], true);
+                } else if (offer1.pay_amt == 0) {
+                    logFill(outstandingPairIDs[x][1], false);
+                }
 
-                    } else if (offer1.pay_amt == 0) {
-                        // ask is non-zerp
-                        logFill(outstandingPairIDs[x][0], true);
-                    } else if (offer1.pay_amt == 0) {
-                        logFill(outstandingPairIDs[x][1], false); 
-                    }
-
-                    // If non-zero real order, cancel
-                    if (offer1.pay_amt != 0 && offer1.pay_amt != 420) {
-                        BathToken(bathAssetAddress).cancel(
-                         outstandingPairIDs[x][0]
-                        );
-                    }
-                    if (offer2.pay_amt != 0 && offer2.pay_amt != 420) {
-                        BathToken(bathQuoteAddress).cancel(
+                // If non-zero real order, cancel
+                if (offer1.pay_amt != 0 && offer1.pay_amt != 420) {
+                    BathToken(bathAssetAddress).cancel(
+                        outstandingPairIDs[x][0]
+                    );
+                }
+                if (offer2.pay_amt != 0 && offer2.pay_amt != 420) {
+                    BathToken(bathQuoteAddress).cancel(
                         outstandingPairIDs[x][1]
                     );
-                    }
-                    removeElement(x);
-                    x--;
-              }
+                }
+                removeElement(x);
+                x--;
+            }
         }
     }
-                        //   cancel both
 
-
+    //   cancel both
 
     // Get offer info from Rubicon Market
     function getOfferInfo(uint256 id) internal view returns (order memory) {
         if (id == 0) {
             order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
             return offerInfo;
-        } else {        
+        } else {
             (
-            uint256 ask_amt,
-            ERC20 ask_gem,
-            uint256 bid_amt,
-            ERC20 bid_gem
-        ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
-        order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
-        return offerInfo;}
-
+                uint256 ask_amt,
+                ERC20 ask_gem,
+                uint256 bid_amt,
+                ERC20 bid_gem
+            ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
+            order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
+            return offerInfo;
+        }
     }
 
     function getOutstandingPairCount() external view returns (uint256) {

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -144,6 +144,10 @@ contract BathToken {
         outstandingIDs.pop();
     }
 
+    function removeFilledTrade(uint id) external onlyPair {
+        removeElement(id2Ind[id]);
+    }
+
     // Rubicon Market Functions:
 
     function cancel(uint256 id) external onlyPair {

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -137,7 +137,9 @@ contract BathToken {
     }
 
     function removeElement(uint256 index) internal {
-        if (index == 0) { return; }
+        if (index == 0) {
+            return;
+        }
         outstandingIDs[index] = outstandingIDs[outstandingIDs.length - 1];
         outstandingIDs.pop();
     }

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -137,6 +137,7 @@ contract BathToken {
     }
 
     function removeElement(uint256 index) internal {
+        if (index == 0) { return; }
         outstandingIDs[index] = outstandingIDs[outstandingIDs.length - 1];
         outstandingIDs.pop();
     }
@@ -144,7 +145,8 @@ contract BathToken {
     // Rubicon Market Functions:
 
     function cancel(uint256 id) external onlyPair {
-        if(id == 0) {return;}
+        emit LogInit(id);
+        emit LogInit(id2Ind[id]);
         RubiconMarket(RubiconMarketAddress).cancel(id);
         removeElement(id2Ind[id]);
     }

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -144,6 +144,7 @@ contract BathToken {
     // Rubicon Market Functions:
 
     function cancel(uint256 id) external onlyPair {
+        if(id == 0) {return;}
         RubiconMarket(RubiconMarketAddress).cancel(id);
         removeElement(id2Ind[id]);
     }

--- a/deploy/002_deploy_testAssets.js
+++ b/deploy/002_deploy_testAssets.js
@@ -294,6 +294,13 @@ const func = async (hre) => {
   //             await bh.setCancelTimeDelay(86400,{gasLimit: g._hex, nonce: getNonce()}).then((r) => console.log("set time delay on BH"));
   //   });
 
+    // // Whitelist a strategist
+    // const bathHouseFactory = await hre.ethers.getContractFactory("BathHouse");
+    // const bh = await bathHouseFactory.attach(process.env.OP_KOVAN_2_BATHHOUSE);
+    // let newStrategist = process.env.OP_KOVAN_ADMIN;
+    // await bh.estimateGas.approveStrategist(newStrategist).then(async function(g) {
+    //           await bh.approveStrategist(newStrategist).then((r) => console.log("approved this strategist ", newStrategist));
+    // });
     
   // // // set market Variable
   //   const bathHouseFactory = await hre.ethers.getContractFactory("RubiconMarket");

--- a/package-lock.json
+++ b/package-lock.json
@@ -3263,7 +3263,6 @@
       "dependencies": {
         "@ledgerhq/hw-app-eth": "5.27.2",
         "@ledgerhq/hw-transport": "5.26.0",
-        "@ledgerhq/hw-transport-node-hid": "5.26.0",
         "@ledgerhq/hw-transport-u2f": "5.26.0",
         "ethers": "^5.3.0"
       },
@@ -5848,9 +5847,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6088,9 +6084,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7764,7 +7757,6 @@
       "dev": true,
       "optional": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -11716,7 +11708,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -13639,8 +13630,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -13802,9 +13792,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -15734,7 +15721,104 @@
       "bundleDependencies": [
         "source-map-support",
         "yargs",
-        "ethereumjs-util"
+        "ethereumjs-util",
+        "@types/bn.js",
+        "@types/node",
+        "@types/pbkdf2",
+        "@types/secp256k1",
+        "ansi-regex",
+        "ansi-styles",
+        "base-x",
+        "blakejs",
+        "bn.js",
+        "brorand",
+        "browserify-aes",
+        "bs58",
+        "bs58check",
+        "buffer-from",
+        "buffer-xor",
+        "camelcase",
+        "cipher-base",
+        "cliui",
+        "color-convert",
+        "color-name",
+        "create-hash",
+        "create-hmac",
+        "cross-spawn",
+        "decamelize",
+        "elliptic",
+        "emoji-regex",
+        "end-of-stream",
+        "ethereum-cryptography",
+        "ethjs-util",
+        "evp_bytestokey",
+        "execa",
+        "find-up",
+        "get-caller-file",
+        "get-stream",
+        "hash-base",
+        "hash.js",
+        "hmac-drbg",
+        "inherits",
+        "invert-kv",
+        "is-fullwidth-code-point",
+        "is-hex-prefixed",
+        "is-stream",
+        "isexe",
+        "keccak",
+        "lcid",
+        "locate-path",
+        "map-age-cleaner",
+        "md5.js",
+        "mem",
+        "mimic-fn",
+        "minimalistic-assert",
+        "minimalistic-crypto-utils",
+        "nice-try",
+        "node-addon-api",
+        "node-gyp-build",
+        "npm-run-path",
+        "once",
+        "os-locale",
+        "p-defer",
+        "p-finally",
+        "p-is-promise",
+        "p-limit",
+        "p-locate",
+        "p-try",
+        "path-exists",
+        "path-key",
+        "pbkdf2",
+        "pump",
+        "randombytes",
+        "readable-stream",
+        "require-directory",
+        "require-main-filename",
+        "ripemd160",
+        "rlp",
+        "safe-buffer",
+        "scrypt-js",
+        "secp256k1",
+        "semver",
+        "set-blocking",
+        "setimmediate",
+        "sha.js",
+        "shebang-command",
+        "shebang-regex",
+        "signal-exit",
+        "source-map",
+        "string_decoder",
+        "string-width",
+        "strip-ansi",
+        "strip-eof",
+        "strip-hex-prefix",
+        "util-deprecate",
+        "which",
+        "which-module",
+        "wrap-ansi",
+        "wrappy",
+        "y18n",
+        "yargs-parser"
       ],
       "dev": true,
       "dependencies": {
@@ -16981,7 +17065,9 @@
       "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.13.2.tgz",
       "integrity": "sha512-tIF5cR+ANQz0+3pHWxHjIwHqFXcVo0Mb+kcsNhglNFALcYo49aQpnS9dqHartqPfMFjiHh/qFoD3mYK0d/qGgw==",
       "bundleDependencies": [
-        "keccak"
+        "keccak",
+        "node-addon-api",
+        "node-gyp-build"
       ],
       "dev": true,
       "hasShrinkwrap": true,
@@ -17001,7 +17087,6 @@
         "ethereumjs-tx": "2.1.2",
         "ethereumjs-util": "6.2.1",
         "ethereumjs-vm": "4.2.0",
-        "ethereumjs-wallet": "0.6.5",
         "heap": "0.2.6",
         "keccak": "3.0.1",
         "level-sublevel": "6.6.4",
@@ -17013,7 +17098,6 @@
         "seedrandom": "3.0.1",
         "source-map-support": "0.5.12",
         "tmp": "0.1.0",
-        "web3": "1.2.11",
         "web3-provider-engine": "14.2.1",
         "websocket": "1.0.32"
       },
@@ -17956,7 +18040,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -18095,9 +18178,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -18276,9 +18356,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -18675,7 +18752,6 @@
         "dom-serializer": "~0.1.0",
         "entities": "~1.1.1",
         "htmlparser2": "~3.8.1",
-        "jsdom": "^7.0.2",
         "lodash": "^4.1.0"
       },
       "engines": {
@@ -19474,7 +19550,6 @@
       "dev": true,
       "optional": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -20681,7 +20756,6 @@
       "dev": true,
       "optional": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -21076,9 +21150,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -21163,9 +21234,6 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -22899,7 +22967,6 @@
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.4.tgz",
       "integrity": "sha512-TielGogIzbUEtd1LsjZFs47RWuHHfhl6TiCx1InVxApBAmQ8bL0dL5ilkLGcRvuyW/A9nE+Lvn855Ewz8S0PnQ==",
       "dependencies": {
-        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.0.0"
@@ -23154,7 +23221,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -25344,9 +25410,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -29764,9 +29827,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -30443,12 +30503,7 @@
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@truffle/db": "^0.5.15",
         "@truffle/debugger": "^9.1.0",
-        "@truffle/preserve-fs": "^0.2.2",
-        "@truffle/preserve-to-buckets": "^0.2.2",
-        "@truffle/preserve-to-filecoin": "^0.2.2",
-        "@truffle/preserve-to-ipfs": "^0.2.2",
         "app-module-path": "^2.2.0",
         "mocha": "8.1.2",
         "original-require": "^1.0.1"
@@ -30639,9 +30694,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -31247,7 +31299,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -31903,9 +31954,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -32035,7 +32083,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {
@@ -32795,10 +32842,8 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -32902,7 +32947,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -33370,7 +33414,6 @@
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@zxing/text-encoding": "0.9.0",
         "util": "^0.12.3"
       },
       "optionalDependencies": {
@@ -42453,9 +42496,7 @@
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
       "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
       "dev": true,
-      "requires": {
-        "ethers": "^5.0.2"
-      }
+      "requires": {}
     },
     "@types/abstract-leveldown": {
       "version": "5.0.1",
@@ -44456,7 +44497,6 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bitcore-lib": "^8.25.10",
         "unorm": "^1.4.1"
       }
     },

--- a/strategist/kovanPoolsStrategist.js
+++ b/strategist/kovanPoolsStrategist.js
@@ -234,7 +234,9 @@ async function logInfo(mA, mB, a, b, im) {
 
 async function checkForScrub(ticker){
         const contract = await getContractFromToken(ticker, "BathPair");
+        // console.log("got this contract", contract);
         await contract.methods.getOutstandingPairCount().call().then(async (r) => {
+            console.log("THIS MANY PAIRS for ", ticker, r);
             if (r > 5 ){
                 // Scrub the bath
                 var txData = await contract.methods.bathScrub().encodeABI();
@@ -248,8 +250,8 @@ async function checkForScrub(ticker){
                 await contract.methods.bathScrub().estimateGas(tx, (async function(r, d) {
                     if (d > 0) { 
                     await sendTx(tx, "\n<* I have successfully scrubbed the " + ticker + " bath, Master *>\n", ticker + " bath Scrub!");
-                    } else{
-                        throw("gas estimation in bathScrub failed");
+                    } else {
+                        // throw("gas estimation in bathScrub failed");
                     }
                 }));
             }
@@ -367,7 +369,7 @@ async function startBot(token, spread) {
             // Sends executeTransaction()
             await marketMake(await currentAsk, await currentBid, await token, await IMfactor, await spread);
         });
-        // console.log('\n⚔⚔⚔ Strategist Bot Market Makes with Diligence and Valor ⚔⚔⚔\n');
+        console.log('\n⚔⚔⚔ Strategist Bot Market Makes with Diligence and Valor ⚔⚔⚔\n');
 
       // Again
       startBot(token, spread);
@@ -388,13 +390,15 @@ const assets = [
     "ETH"
 ];
 
-// Start bots
-for (let index = 0; index < assets.length; index++) {
-    const element = assets[index];
-    startBot(element, 0.02);
-    // startBot(element, 0.04);
-    // startBot(element, 0.07);
-}
+// // Start bots
+// for (let index = 0; index < assets.length; index++) {
+//     const element = assets[index];
+//     startBot(element, 0.02);
+//     // startBot(element, 0.04);
+//     // startBot(element, 0.07);
+// }
+
+startBot("ETH", 0.02);
 
 
 

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -33,7 +33,7 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
 
         it("Bath House is deployed and initialized", async function() {
             // Call initialize on Bath house
-            return await bathHouseInstance.initialize(rubiconMarketInstance.address, 80, 1000, 10);
+            return await bathHouseInstance.initialize(rubiconMarketInstance.address, 80, 1, 10);
         });
         it("Bath Token for asset is deployed and initialized", async function() {
             return await BathToken.new().then(async function(instance) {
@@ -67,34 +67,34 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
             assert.equal(await bathPairInstance.bathAssetAddress(), bathAssetInstance.address);
             assert.equal(await bathPairInstance.bathQuoteAddress(), bathQuoteInstance.address);
         });
-        it("bath tokens have the right name", async function() {
-            assert.equal(await bathAssetInstance.symbol(), "bathWETH");
-            assert.equal(await bathQuoteInstance.symbol(), "bathDAI");
-        });
-        it("User can deposit asset funds with custom weights and receive bathTokens", async function() {
-            await WETHInstance.deposit({from: accounts[1], value: web3.utils.toWei((1).toString())})
-            await WETHInstance.approve(bathAssetInstance.address, web3.utils.toWei((1).toString()), {from: accounts[1]});
-            await bathAssetInstance.deposit(web3.utils.toWei((1).toString()), {from: accounts[1]});
-            assert.equal((await bathAssetInstance.balanceOf(accounts[1])).toString(), web3.utils.toWei((1).toString()));            
-        });
-        it("User can deposit quote funds with custom weights and receive bathTokens", async function() {
-            await DAIInstance.faucet({from: accounts[2]});
-            await DAIInstance.approve(bathQuoteInstance.address, web3.utils.toWei((100).toString()), {from: accounts[2]});
-            await bathQuoteInstance.deposit(web3.utils.toWei((100).toString()), {from: accounts[2]});
-            assert.equal((await bathQuoteInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei((100).toString()));            
-        });
-        it("Withdraw asset funds by sending in bathTokens", async function() {
-            await bathAssetInstance.withdraw(web3.utils.toWei((1).toString()), {from: accounts[1]});
-            assert.equal(await WETHInstance.balanceOf(accounts[1]), web3.utils.toWei((1).toString()));
-        });
-        it("Withdraw quote funds by sending in bathTokens", async function() {
-            await bathQuoteInstance.withdraw(web3.utils.toWei((100).toString()), {from: accounts[2]});
-            assert.equal((await DAIInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei("1000").toString());
-        });
-        it("both users have no bath Tokens post withdraw", async function() {
-            assert.equal("0", await bathAssetInstance.balanceOf(accounts[1]));
-            assert.equal("0", await bathQuoteInstance.balanceOf(accounts[2]));
-        });
+        // it("bath tokens have the right name", async function() {
+        //     assert.equal(await bathAssetInstance.symbol(), "bathWETH");
+        //     assert.equal(await bathQuoteInstance.symbol(), "bathDAI");
+        // });
+        // it("User can deposit asset funds with custom weights and receive bathTokens", async function() {
+        //     await WETHInstance.deposit({from: accounts[1], value: web3.utils.toWei((1).toString())})
+        //     await WETHInstance.approve(bathAssetInstance.address, web3.utils.toWei((1).toString()), {from: accounts[1]});
+        //     await bathAssetInstance.deposit(web3.utils.toWei((1).toString()), {from: accounts[1]});
+        //     assert.equal((await bathAssetInstance.balanceOf(accounts[1])).toString(), web3.utils.toWei((1).toString()));            
+        // });
+        // it("User can deposit quote funds with custom weights and receive bathTokens", async function() {
+        //     await DAIInstance.faucet({from: accounts[2]});
+        //     await DAIInstance.approve(bathQuoteInstance.address, web3.utils.toWei((100).toString()), {from: accounts[2]});
+        //     await bathQuoteInstance.deposit(web3.utils.toWei((100).toString()), {from: accounts[2]});
+        //     assert.equal((await bathQuoteInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei((100).toString()));            
+        // });
+        // it("Withdraw asset funds by sending in bathTokens", async function() {
+        //     await bathAssetInstance.withdraw(web3.utils.toWei((1).toString()), {from: accounts[1]});
+        //     assert.equal(await WETHInstance.balanceOf(accounts[1]), web3.utils.toWei((1).toString()));
+        // });
+        // it("Withdraw quote funds by sending in bathTokens", async function() {
+        //     await bathQuoteInstance.withdraw(web3.utils.toWei((100).toString()), {from: accounts[2]});
+        //     assert.equal((await DAIInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei("1000").toString());
+        // });
+        // it("both users have no bath Tokens post withdraw", async function() {
+        //     assert.equal("0", await bathAssetInstance.balanceOf(accounts[1]));
+        //     assert.equal("0", await bathQuoteInstance.balanceOf(accounts[2]));
+        // });
     });
 
     // Test Market making functionality:
@@ -163,24 +163,28 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
             await bathPairInstance.removeLiquidity(8);
             // assert.equal((await bathPairInstance.getOutstandingPairCount()).toString(), "2");
         });
-        it("New strategist can be added to pools", async function () {
+        it("New strategist can be added to pools ", async function () {
             await bathHouseInstance.approveStrategist(accounts[6]);
             await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator, {from: accounts[6]});
-            await bathPairInstance.removeLiquidity(10, {from: accounts[6]});
+            // await bathPairInstance.removeLiquidity(10, {from: accounts[6]});
         });
-        // for (let i = 1; i < 10; i++) {
-        //     it(`Spamming of executeStrategy iteration: ${i}`, async function () {
-        //         await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator);
-
-        //         await rubiconMarketInstance.buy(8 + (i*2), web3.utils.toWei((0.4).toString()), { from: accounts[5] });
-        //         // console.log(await bathPairInstance.executeStrategy.estimateGas(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator));
-        //         // console.log("IDs of new trades: ",  await bathPairInstance.getLastTradeIDs());
-        //         if (i % 3) {
-        //             await bathPairInstance.bathScrub();
-        //         }
-        //         // console.log("outstanding pairs: ", await bathPairInstance.getOutstandingPairCount());
-        //     });
-        // }
+        for (let i = 1; i < 10; i++) {
+            it(`Spamming of executeStrategy iteration: ${i}`, async function () {
+                await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator);
+                // TODO: log gas while looping through multiple bathScrub calls
+                // See how it scales and if a solution is available to make it more gas efficient
+                // --> why in the OVM is bathScrub failing? This is the goal...
+                
+                await rubiconMarketInstance.buy(8 + (i*2), web3.utils.toWei((0.4).toString()), { from: accounts[5] });
+                // console.log(await bathPairInstance.executeStrategy.estimateGas(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator));
+                // console.log("IDs of new trades: ",  await bathPairInstance.getLastTradeIDs());
+                let outstandingPairs = await bathPairInstance.getOutstandingPairCount();
+                if (outstandingPairs > 5) {
+                    await bathPairInstance.bathScrub();
+                }
+                // console.log("outstanding pairs: ", await bathPairInstance.getOutstandingPairCount());
+            });
+        }
         it("Funds are correctly returned to bathTokens", async function () {
             await bathPairInstance.bathScrub();
             assert.equal((await WETHInstance.balanceOf(bathQuoteInstance.address)).toString(),"0");

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -33,7 +33,7 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
 
         it("Bath House is deployed and initialized", async function() {
             // Call initialize on Bath house
-            return await bathHouseInstance.initialize(rubiconMarketInstance.address, 80, 1, 10);
+            return await bathHouseInstance.initialize(rubiconMarketInstance.address, 80, 10, 10);
         });
         it("Bath Token for asset is deployed and initialized", async function() {
             return await BathToken.new().then(async function(instance) {
@@ -160,7 +160,7 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
         });
         it("Strategist can cancel an order they made", async function () {
             
-            await bathPairInstance.removeLiquidity(8);
+            await bathPairInstance.removeLiquidity(7);
             // assert.equal((await bathPairInstance.getOutstandingPairCount()).toString(), "2");
         });
         it("New strategist can be added to pools ", async function () {
@@ -168,23 +168,23 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
             await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator, {from: accounts[6]});
             // await bathPairInstance.removeLiquidity(10, {from: accounts[6]});
         });
-        for (let i = 1; i < 10; i++) {
-            it(`Spamming of executeStrategy iteration: ${i}`, async function () {
-                await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator);
-                // TODO: log gas while looping through multiple bathScrub calls
-                // See how it scales and if a solution is available to make it more gas efficient
-                // --> why in the OVM is bathScrub failing? This is the goal...
+        // for (let i = 1; i < 10; i++) {
+        //     it(`Spamming of executeStrategy iteration: ${i}`, async function () {
+        //         await bathPairInstance.executeStrategy(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator);
+        //         // TODO: log gas while looping through multiple bathScrub calls
+        //         // See how it scales and if a solution is available to make it more gas efficient
+        //         // --> why in the OVM is bathScrub failing? This is the goal...
                 
-                await rubiconMarketInstance.buy(8 + (i*2), web3.utils.toWei((0.4).toString()), { from: accounts[5] });
-                // console.log(await bathPairInstance.executeStrategy.estimateGas(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator));
-                // console.log("IDs of new trades: ",  await bathPairInstance.getLastTradeIDs());
-                let outstandingPairs = await bathPairInstance.getOutstandingPairCount();
-                if (outstandingPairs > 5) {
-                    await bathPairInstance.bathScrub();
-                }
-                // console.log("outstanding pairs: ", await bathPairInstance.getOutstandingPairCount());
-            });
-        }
+        //         await rubiconMarketInstance.buy(8 + (i*2), web3.utils.toWei((0.4).toString()), { from: accounts[5] });
+        //         // console.log(await bathPairInstance.executeStrategy.estimateGas(strategyInstance.address, askNumerator, askDenominator, bidNumerator, bidDenominator));
+        //         // console.log("IDs of new trades: ",  await bathPairInstance.getLastTradeIDs());
+        //         let outstandingPairs = await bathPairInstance.getOutstandingPairCount();
+        //         if (outstandingPairs > 5) {
+        //             await bathPairInstance.bathScrub();
+        //         }
+        //         // console.log("outstanding pairs: ", await bathPairInstance.getOutstandingPairCount());
+        //     });
+        // }
         it("Funds are correctly returned to bathTokens", async function () {
             await bathPairInstance.bathScrub();
             assert.equal((await WETHInstance.balanceOf(bathQuoteInstance.address)).toString(),"0");

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -67,34 +67,34 @@ contract("Rubicon Exchange and Pools Test", async function(accounts) {
             assert.equal(await bathPairInstance.bathAssetAddress(), bathAssetInstance.address);
             assert.equal(await bathPairInstance.bathQuoteAddress(), bathQuoteInstance.address);
         });
-        // it("bath tokens have the right name", async function() {
-        //     assert.equal(await bathAssetInstance.symbol(), "bathWETH");
-        //     assert.equal(await bathQuoteInstance.symbol(), "bathDAI");
-        // });
-        // it("User can deposit asset funds with custom weights and receive bathTokens", async function() {
-        //     await WETHInstance.deposit({from: accounts[1], value: web3.utils.toWei((1).toString())})
-        //     await WETHInstance.approve(bathAssetInstance.address, web3.utils.toWei((1).toString()), {from: accounts[1]});
-        //     await bathAssetInstance.deposit(web3.utils.toWei((1).toString()), {from: accounts[1]});
-        //     assert.equal((await bathAssetInstance.balanceOf(accounts[1])).toString(), web3.utils.toWei((1).toString()));            
-        // });
-        // it("User can deposit quote funds with custom weights and receive bathTokens", async function() {
-        //     await DAIInstance.faucet({from: accounts[2]});
-        //     await DAIInstance.approve(bathQuoteInstance.address, web3.utils.toWei((100).toString()), {from: accounts[2]});
-        //     await bathQuoteInstance.deposit(web3.utils.toWei((100).toString()), {from: accounts[2]});
-        //     assert.equal((await bathQuoteInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei((100).toString()));            
-        // });
-        // it("Withdraw asset funds by sending in bathTokens", async function() {
-        //     await bathAssetInstance.withdraw(web3.utils.toWei((1).toString()), {from: accounts[1]});
-        //     assert.equal(await WETHInstance.balanceOf(accounts[1]), web3.utils.toWei((1).toString()));
-        // });
-        // it("Withdraw quote funds by sending in bathTokens", async function() {
-        //     await bathQuoteInstance.withdraw(web3.utils.toWei((100).toString()), {from: accounts[2]});
-        //     assert.equal((await DAIInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei("1000").toString());
-        // });
-        // it("both users have no bath Tokens post withdraw", async function() {
-        //     assert.equal("0", await bathAssetInstance.balanceOf(accounts[1]));
-        //     assert.equal("0", await bathQuoteInstance.balanceOf(accounts[2]));
-        // });
+        it("bath tokens have the right name", async function() {
+            assert.equal(await bathAssetInstance.symbol(), "bathWETH");
+            assert.equal(await bathQuoteInstance.symbol(), "bathDAI");
+        });
+        it("User can deposit asset funds with custom weights and receive bathTokens", async function() {
+            await WETHInstance.deposit({from: accounts[1], value: web3.utils.toWei((1).toString())})
+            await WETHInstance.approve(bathAssetInstance.address, web3.utils.toWei((1).toString()), {from: accounts[1]});
+            await bathAssetInstance.deposit(web3.utils.toWei((1).toString()), {from: accounts[1]});
+            assert.equal((await bathAssetInstance.balanceOf(accounts[1])).toString(), web3.utils.toWei((1).toString()));            
+        });
+        it("User can deposit quote funds with custom weights and receive bathTokens", async function() {
+            await DAIInstance.faucet({from: accounts[2]});
+            await DAIInstance.approve(bathQuoteInstance.address, web3.utils.toWei((100).toString()), {from: accounts[2]});
+            await bathQuoteInstance.deposit(web3.utils.toWei((100).toString()), {from: accounts[2]});
+            assert.equal((await bathQuoteInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei((100).toString()));            
+        });
+        it("Withdraw asset funds by sending in bathTokens", async function() {
+            await bathAssetInstance.withdraw(web3.utils.toWei((1).toString()), {from: accounts[1]});
+            assert.equal(await WETHInstance.balanceOf(accounts[1]), web3.utils.toWei((1).toString()));
+        });
+        it("Withdraw quote funds by sending in bathTokens", async function() {
+            await bathQuoteInstance.withdraw(web3.utils.toWei((100).toString()), {from: accounts[2]});
+            assert.equal((await DAIInstance.balanceOf(accounts[2])).toString(), web3.utils.toWei("1000").toString());
+        });
+        it("both users have no bath Tokens post withdraw", async function() {
+            assert.equal("0", await bathAssetInstance.balanceOf(accounts[1]));
+            assert.equal("0", await bathQuoteInstance.balanceOf(accounts[2]));
+        });
     });
 
     // Test Market making functionality:

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -15,6 +15,10 @@ module.exports = {
       network_id: "*", // Match any network id
       gas: 10000000,  
     },
+    // OPKovan: {
+    //   host: "",
+    //   network_id: 69
+    // },
     kovan: {
       networkCheckTimeout: 10000,
       provider: function() {


### PR DESCRIPTION
This PR improves the functionality of `bathScrub()` and reduces the total lines of code on BathPair.sol by about 100 while also reducing the gas complexity of the function call.

Importantly, in Pools, trades placed by strategists are only checked after time expiry (a system-wide length of time set on BathHouse). During this check, the system logs any _complete fills_ and their strategist for future yield claims. Moreover, this increases the importance of having a high-frequency of `bathScrub()` used in the system - something that is enforced by `outstandingPairIDs` and BathHouse's `timeDelay`.

My hope is that with this added gas optimization, a larger quantity of pairs can be outstanding while not growing the gas complexity of the BathPair for loop (`cancelPartialFills`) allowing for a larger number of higher-frequency trades.