### PR TITLE
Update bathToken liquidity management logic

### DIFF
--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -17,624 +17,587 @@ import "../interfaces/IBidAskUtil.sol";
 import "../peripheral_contracts/ABDKMath64x64.sol";
 
 contract BathPair {
-    using SafeMath for uint256;
+  using SafeMath for uint256;
 
-    address public bathHouse;
-    address public underlyingAsset;
-    address public underlyingQuote;
+  address public bathHouse;
+  address public underlyingAsset;
+  address public underlyingQuote;
 
-    address public bathAssetAddress;
-    address public bathQuoteAddress;
+  address public bathAssetAddress;
+  address public bathQuoteAddress;
 
-    address public RubiconMarketAddress;
+  address public RubiconMarketAddress;
 
-    bool public initialized;
+  bool public initialized;
 
-    int128 internal shapeCoefNum;
-    uint256 public maxOrderSizeBPS;
+  int128 internal shapeCoefNum;
+  uint256 public maxOrderSizeBPS;
 
-    /// @dev Internal variables for localalized searching in bathScrub
-    uint256 internal start;
-    uint256 internal searchRadius;
+  /// @dev Internal variables for localalized searching in bathScrub
+  uint256 internal start;
+  uint256 internal searchRadius;
 
-    uint256 internal totalAssetFills;
-    uint256 internal totalQuoteFills;
+  uint256 internal totalAssetFills;
+  uint256 internal totalQuoteFills;
 
-    /// @dev askID, bidID, timestamp
-    uint256[3][] public outstandingPairIDs;
+  /// @dev askID, bidID, timestamp
+  uint256[3][] public outstandingPairIDs;
 
-    event LogNote(string, uint256, uint256);
-    event LogStrategistTrades(
-        uint256 idAsk,
-        address askAsset,
-        uint256 idBid,
-        address bidAsset,
-        address strategist,
-        uint256 timestamp
+  event LogNote(string, uint256, uint256);
+  event LogStrategistTrades(
+    uint256 idAsk,
+    address askAsset,
+    uint256 idBid,
+    address bidAsset,
+    address strategist,
+    uint256 timestamp
+  );
+
+  /// @dev Maps a trade ID to each of their strategists for rewards purposes
+  mapping(uint256 => address) public IDs2strategist;
+  mapping(address => uint256) public strategist2FillsAsset;
+  mapping(address => uint256) public strategist2FillsQuote;
+
+  struct order {
+    uint256 pay_amt;
+    ERC20 pay_gem;
+    uint256 buy_amt;
+    ERC20 buy_gem;
+  }
+
+  /// @dev Proxy-safe initialization of storage
+  function initialize(
+    address _bathAssetAddress,
+    address _bathQuoteAddress,
+    address _bathHouse,
+    uint256 _maxOrderSizeBPS,
+    int128 _shapeCoefNum
+  ) external {
+    require(!initialized);
+    bathHouse = _bathHouse;
+
+    bathAssetAddress = _bathAssetAddress;
+    bathQuoteAddress = _bathQuoteAddress;
+
+    require(
+      BathToken(bathAssetAddress).underlying() !=
+        address(0x0000000000000000000000000000000000000000)
+    );
+    require(
+      BathToken(bathQuoteAddress).underlying() !=
+        address(0x0000000000000000000000000000000000000000)
+    );
+    underlyingAsset = BathToken(bathAssetAddress).underlying();
+    underlyingQuote = BathToken(bathQuoteAddress).underlying();
+
+    require(
+      BathHouse(bathHouse).getMarket() !=
+        address(0x0000000000000000000000000000000000000000)
+    );
+    RubiconMarketAddress = BathHouse(bathHouse).getMarket();
+
+    maxOrderSizeBPS = _maxOrderSizeBPS;
+    shapeCoefNum = _shapeCoefNum;
+    start = 0;
+    searchRadius = 3;
+    initialized = true;
+  }
+
+  modifier onlyBathHouse {
+    require(msg.sender == bathHouse);
+    _;
+  }
+
+  modifier onlyApprovedStrategy(address targetStrategy) {
+    require(
+      BathHouse(bathHouse).isApprovedStrat(targetStrategy) == true,
+      "not an approved strategy - bathPair"
+    );
+    _;
+  }
+
+  modifier onlyApprovedStrategist(address targetStrategist) {
+    require(
+      BathHouse(bathHouse).isApprovedStrategist(targetStrategist) == true,
+      "you are not an approved strategist - bathPair"
+    );
+    _;
+  }
+
+  modifier enforceReserveRatio {
+    require(
+      (
+        BathToken(bathAssetAddress).totalSupply().mul(
+          BathHouse(bathHouse).reserveRatio()
+        )
+      )
+      .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+    );
+    require(
+      (
+        BathToken(bathQuoteAddress).totalSupply().mul(
+          BathHouse(bathHouse).reserveRatio()
+        )
+      )
+      .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+    );
+    _;
+    require(
+      (
+        BathToken(bathAssetAddress).totalSupply().mul(
+          BathHouse(bathHouse).reserveRatio()
+        )
+      )
+      .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+    );
+    require(
+      (
+        BathToken(bathQuoteAddress).totalSupply().mul(
+          BathHouse(bathHouse).reserveRatio()
+        )
+      )
+      .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+    );
+  }
+
+  function setMaxOrderSizeBPS(uint16 val) external onlyBathHouse {
+    maxOrderSizeBPS = val;
+  }
+
+  function setShapeCoefNum(int128 val) external onlyBathHouse {
+    shapeCoefNum = val;
+  }
+
+  function setSearchRadius(uint256 val) external onlyBathHouse {
+    searchRadius = val;
+  }
+
+  function getMidpointPrice() internal view returns (int128) {
+    uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+      ERC20(underlyingAsset),
+      ERC20(underlyingQuote)
+    );
+    uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+      ERC20(underlyingQuote),
+      ERC20(underlyingAsset)
+    );
+    require(
+      bestAskID > 0 && bestBidID > 0,
+      "bids or asks are missing to get a Midpoint"
     );
 
-    /// @dev Maps a trade ID to each of their strategists for rewards purposes
-    mapping(uint256 => address) public IDs2strategist;
-    mapping(address => uint256) public strategist2FillsAsset;
-    mapping(address => uint256) public strategist2FillsQuote;
+    order memory bestAsk = getOfferInfo(bestAskID);
+    order memory bestBid = getOfferInfo(bestBidID);
+    int128 midpoint = ABDKMath64x64.divu(
+      (
+        (bestAsk.buy_amt.div(bestAsk.pay_amt)).add(
+          bestBid.pay_amt.div(bestBid.buy_amt)
+        )
+      ),
+      2
+    );
+    return midpoint;
+  }
 
-    struct order {
-        uint256 pay_amt;
-        ERC20 pay_gem;
-        uint256 buy_amt;
-        ERC20 buy_gem;
-    }
+  // Takes the proposed bid and ask as a parameter - that the offers placed won't match and are maker orders
+  // bid price > best ask
+  function enforceSpread(
+    uint256 askN,
+    uint256 askD,
+    uint256 bidN,
+    uint256 bidD
+  ) internal view {
+    require(
+      (askN > 0 && askD > 0) || (bidN > 0 && bidD > 0),
+      "one order must be non-zero"
+    );
 
-    /// @dev Proxy-safe initialization of storage
-    function initialize(
-        address _bathAssetAddress,
-        address _bathQuoteAddress,
-        address _bathHouse,
-        uint256 _maxOrderSizeBPS,
-        int128 _shapeCoefNum
-    ) external {
-        require(!initialized);
-        bathHouse = _bathHouse;
+    uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+      ERC20(underlyingAsset),
+      ERC20(underlyingQuote)
+    );
+    uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+      ERC20(underlyingQuote),
+      ERC20(underlyingAsset)
+    );
 
-        bathAssetAddress = _bathAssetAddress;
-        bathQuoteAddress = _bathQuoteAddress;
+    order memory bestAsk = getOfferInfo(bestAskID);
+    order memory bestBid = getOfferInfo(bestBidID);
 
+    // If orders in the order book, adhere to more constraints
+    if (
+      bestAsk.pay_amt > 0 &&
+      bestAsk.buy_amt > 0 &&
+      bestBid.pay_amt > 0 &&
+      bestBid.buy_amt > 0
+    ) {
+      if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
         require(
-            BathToken(bathAssetAddress).underlying() !=
-                address(0x0000000000000000000000000000000000000000)
+          ((bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN))) &&
+            ((askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN))),
+          "bid must be < bestAsk && ask must be > best Bid in Price"
         );
+      } else if (bidN > 0 && bidD > 0) {
+        // Goal is for (bestAsk.buy_amt / bestAsk.pay_amt) > (bidNumerator / bidDenominator)
         require(
-            BathToken(bathQuoteAddress).underlying() !=
-                address(0x0000000000000000000000000000000000000000)
+          (bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN)),
+          "bid price is not less than the best ask"
         );
-        underlyingAsset = BathToken(bathAssetAddress).underlying();
-        underlyingQuote = BathToken(bathQuoteAddress).underlying();
-
+      } else if (askN > 0 && askD > 0) {
+        // Goal is for (askDenominator / askNumerator) > (bestBid.pay_amt / bestBid.buy_amt)
         require(
-            BathHouse(bathHouse).getMarket() !=
-                address(0x0000000000000000000000000000000000000000)
+          (askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN)),
+          "ask price not greater than best bid"
         );
-        RubiconMarketAddress = BathHouse(bathHouse).getMarket();
+      }
+    }
+    // check that ask price > bid price if two offers given
+    if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
+      require((askD.mul(bidD)) > (bidN.mul(askN)));
+    }
+  }
 
-        maxOrderSizeBPS = _maxOrderSizeBPS;
-        shapeCoefNum = _shapeCoefNum;
-        start = 0;
-        searchRadius = 3;
-        initialized = true;
+  function getThisBathQuote() external view returns (address) {
+    require(initialized);
+    return bathQuoteAddress;
+  }
+
+  function getThisBathAsset() external view returns (address) {
+    require(initialized);
+    return bathAssetAddress;
+  }
+
+  // Returns filled liquidity to the correct bath pool
+  function rebalancePair() internal {
+    uint256 bathAssetYield = ERC20(underlyingQuote).balanceOf(bathAssetAddress);
+    uint256 bathQuoteYield = ERC20(underlyingAsset).balanceOf(bathQuoteAddress);
+    uint16 stratReward = BathHouse(bathHouse).getBPSToStrats(address(this));
+    if (bathAssetYield > 0) {
+      BathToken(bathAssetAddress).rebalance(
+        bathQuoteAddress,
+        underlyingQuote,
+        stratReward
+      );
     }
 
-    modifier onlyBathHouse {
-        require(msg.sender == bathHouse);
-        _;
+    if (bathQuoteYield > 0) {
+      BathToken(bathQuoteAddress).rebalance(
+        bathAssetAddress,
+        underlyingAsset,
+        stratReward
+      );
+    }
+  }
+
+  // function where strategists claim rewards proportional to their quantity of fills
+  function strategistBootyClaim() external {
+    uint256 fillCountA = strategist2FillsAsset[msg.sender];
+    uint256 fillCountQ = strategist2FillsQuote[msg.sender];
+    if (fillCountA > 0) {
+      uint256 booty = (
+        fillCountA.mul(ERC20(underlyingAsset).balanceOf(address(this)))
+      )
+      .div(totalAssetFills);
+      IERC20(underlyingAsset).transfer(msg.sender, booty);
+      totalAssetFills -= fillCountA;
+    }
+    if (fillCountQ > 0) {
+      uint256 booty = (
+        fillCountQ.mul(ERC20(underlyingQuote).balanceOf(address(this)))
+      )
+      .div(totalQuoteFills);
+      IERC20(underlyingQuote).transfer(msg.sender, booty);
+      totalQuoteFills -= fillCountQ;
+    }
+  }
+
+  function addOutstandingPair(uint256[3] calldata IDPair)
+    external
+    onlyApprovedStrategy(msg.sender)
+  {
+    require(IDPair.length == 3);
+    outstandingPairIDs.push(IDPair);
+  }
+
+  // orderID of the fill
+  // only log fills for each strategist - needs to be asset specific
+  // isAssetFill are *quotes* that result in asset yield
+  function logFill(uint256 orderID, bool isAssetFill) internal {
+    // Goal is to map a fill to a strategist
+    if (isAssetFill) {
+      strategist2FillsAsset[IDs2strategist[orderID]] += 1;
+      totalAssetFills += 1;
+    } else {
+      strategist2FillsQuote[IDs2strategist[orderID]] += 1;
+      totalQuoteFills += 1;
+    }
+  }
+
+  function removeElement(uint256 index) internal {
+    outstandingPairIDs[index] = outstandingPairIDs[
+      outstandingPairIDs.length - 1
+    ];
+    outstandingPairIDs.pop();
+  }
+
+  function cancelPartialFills() internal {
+    uint256 timeDelay = BathHouse(bathHouse).timeDelay();
+    uint256 len = outstandingPairIDs.length;
+    uint256 _start = start;
+
+    uint256 _searchRadius = searchRadius;
+    if (_start + _searchRadius >= len) {
+      // start over from beggining
+      if (_searchRadius >= len) {
+        _start = 0;
+        _searchRadius = len;
+      } else {
+        _searchRadius = len - _start;
+      }
     }
 
-    modifier onlyApprovedStrategy(address targetStrategy) {
-        require(
-            BathHouse(bathHouse).isApprovedStrat(targetStrategy) == true,
-            "not an approved strategy - bathPair"
-        );
-        _;
-    }
+    for (uint256 x = _start; x < _start + _searchRadius; x++) {
+      if (outstandingPairIDs[x][2] < (block.timestamp - timeDelay)) {
+        uint256 askId = outstandingPairIDs[x][0];
+        uint256 bidId = outstandingPairIDs[x][1];
+        order memory offer1 = getOfferInfo(askId);
+        order memory offer2 = getOfferInfo(bidId);
 
-    modifier onlyApprovedStrategist(address targetStrategist) {
-        require(
-            BathHouse(bathHouse).isApprovedStrategist(targetStrategist) == true,
-            "you are not an approved strategist - bathPair"
-        );
-        _;
-    }
-
-    modifier enforceReserveRatio {
-        require(
-            (
-                BathToken(bathAssetAddress).totalSupply().mul(
-                    BathHouse(bathHouse).reserveRatio()
-                )
-            )
-            .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-        );
-        require(
-            (
-                BathToken(bathQuoteAddress).totalSupply().mul(
-                    BathHouse(bathHouse).reserveRatio()
-                )
-            )
-            .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-        );
-        _;
-        require(
-            (
-                BathToken(bathAssetAddress).totalSupply().mul(
-                    BathHouse(bathHouse).reserveRatio()
-                )
-            )
-            .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-        );
-        require(
-            (
-                BathToken(bathQuoteAddress).totalSupply().mul(
-                    BathHouse(bathHouse).reserveRatio()
-                )
-            )
-            .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-        );
-    }
-
-    function setMaxOrderSizeBPS(uint16 val) external onlyBathHouse {
-        maxOrderSizeBPS = val;
-    }
-
-    function setShapeCoefNum(int128 val) external onlyBathHouse {
-        shapeCoefNum = val;
-    }
-
-    function setSearchRadius(uint256 val) external onlyBathHouse {
-        searchRadius = val;
-    }
-
-    function getMidpointPrice() internal view returns (int128) {
-        uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-            ERC20(underlyingAsset),
-            ERC20(underlyingQuote)
-        );
-        uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-            ERC20(underlyingQuote),
-            ERC20(underlyingAsset)
-        );
-        require(
-            bestAskID > 0 && bestBidID > 0,
-            "bids or asks are missing to get a Midpoint"
-        );
-
-        order memory bestAsk = getOfferInfo(bestAskID);
-        order memory bestBid = getOfferInfo(bestBidID);
-        int128 midpoint = ABDKMath64x64.divu(
-            (
-                (bestAsk.buy_amt.div(bestAsk.pay_amt)).add(
-                    bestBid.pay_amt.div(bestBid.buy_amt)
-                )
-            ),
-            2
-        );
-        return midpoint;
-    }
-
-    // Takes the proposed bid and ask as a parameter - that the offers placed won't match and are maker orders
-    // bid price > best ask
-    function enforceSpread(
-        uint256 askN,
-        uint256 askD,
-        uint256 bidN,
-        uint256 bidD
-    ) internal view {
-        require(
-            (askN > 0 && askD > 0) || (bidN > 0 && bidD > 0),
-            "one order must be non-zero"
-        );
-
-        uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-            ERC20(underlyingAsset),
-            ERC20(underlyingQuote)
-        );
-        uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-            ERC20(underlyingQuote),
-            ERC20(underlyingAsset)
-        );
-
-        order memory bestAsk = getOfferInfo(bestAskID);
-        order memory bestBid = getOfferInfo(bestBidID);
-
-        // If orders in the order book, adhere to more constraints
-        if (
-            bestAsk.pay_amt > 0 &&
-            bestAsk.buy_amt > 0 &&
-            bestBid.pay_amt > 0 &&
-            bestBid.buy_amt > 0
-        ) {
-            if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
-                require(
-                    ((bestAsk.buy_amt.mul(bidD)) >
-                        (bestAsk.pay_amt.mul(bidN))) &&
-                        ((askD.mul(bestBid.buy_amt)) >
-                            (bestBid.pay_amt.mul(askN))),
-                    "bid must be < bestAsk && ask must be > best Bid in Price"
-                );
-            } else if (bidN > 0 && bidD > 0) {
-                // Goal is for (bestAsk.buy_amt / bestAsk.pay_amt) > (bidNumerator / bidDenominator)
-                require(
-                    (bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN)),
-                    "bid price is not less than the best ask"
-                );
-            } else if (askN > 0 && askD > 0) {
-                // Goal is for (askDenominator / askNumerator) > (bestBid.pay_amt / bestBid.buy_amt)
-                require(
-                    (askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN)),
-                    "ask price not greater than best bid"
-                );
-            }
-        }
-        // check that ask price > bid price if two offers given
-        if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
-            require((askD.mul(bidD)) > (bidN.mul(askN)));
-        }
-    }
-
-    function getThisBathQuote() external view returns (address) {
-        require(initialized);
-        return bathQuoteAddress;
-    }
-
-    function getThisBathAsset() external view returns (address) {
-        require(initialized);
-        return bathAssetAddress;
-    }
-
-    // Returns filled liquidity to the correct bath pool
-    function rebalancePair() internal {
-        uint256 bathAssetYield = ERC20(underlyingQuote).balanceOf(
-            bathAssetAddress
-        );
-        uint256 bathQuoteYield = ERC20(underlyingAsset).balanceOf(
-            bathQuoteAddress
-        );
-        uint16 stratReward = BathHouse(bathHouse).getBPSToStrats(address(this));
-        if (bathAssetYield > 0) {
-            BathToken(bathAssetAddress).rebalance(
-                bathQuoteAddress,
-                underlyingQuote,
-                stratReward
-            );
+        // if real
+        if (askId != 0) {
+          // if filled
+          if (offer1.pay_amt == 0) {
+            logFill(askId, true);
+            BathToken(bathAssetAddress).removeFilledTrade(askId);
+          }
+          // otherwise didn't fill so cancel and handle a partial fill
+          else {
+            BathToken(bathAssetAddress).cancel(askId);
+          }
         }
 
-        if (bathQuoteYield > 0) {
-            BathToken(bathQuoteAddress).rebalance(
-                bathAssetAddress,
-                underlyingAsset,
-                stratReward
-            );
+        // if real
+        if (bidId != 0) {
+          // if filled
+          if (offer2.pay_amt == 0) {
+            logFill(bidId, false);
+            BathToken(bathQuoteAddress).removeFilledTrade(bidId);
+          }
+          // otherwise didn't fill so cancel and handle a partial fill
+          else {
+            BathToken(bathQuoteAddress).cancel(bidId);
+          }
         }
+        removeElement(x);
+        x--;
+        _searchRadius--;
+      }
     }
+    if (_start + searchRadius >= len) {
+      start = 0;
+    } else {
+      start = _start + searchRadius;
+    }
+  }
 
-    // function where strategists claim rewards proportional to their quantity of fills
-    function strategistBootyClaim() external {
-        uint256 fillCountA = strategist2FillsAsset[msg.sender];
-        uint256 fillCountQ = strategist2FillsQuote[msg.sender];
-        if (fillCountA > 0) {
-            uint256 booty = (
-                fillCountA.mul(ERC20(underlyingAsset).balanceOf(address(this)))
-            )
-            .div(totalAssetFills);
-            IERC20(underlyingAsset).transfer(msg.sender, booty);
-            totalAssetFills -= fillCountA;
+  // Get offer info from Rubicon Market
+  function getOfferInfo(uint256 id) internal view returns (order memory) {
+    if (id == 0) {
+      order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
+      return offerInfo;
+    } else {
+      (
+        uint256 ask_amt,
+        ERC20 ask_gem,
+        uint256 bid_amt,
+        ERC20 bid_gem
+      ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
+      order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
+      return offerInfo;
+    }
+  }
+
+  function getOutstandingPairCount() external view returns (uint256) {
+    return outstandingPairIDs.length;
+  }
+
+  function getSearchRadius() external view returns (uint256) {
+    return searchRadius;
+  }
+
+  // this throws on a zero value ofliquidity
+  function getMaxOrderSize(address asset, address bathTokenAddress)
+    public
+    view
+    returns (uint256 maxOrderSize)
+  {
+    require(asset == underlyingAsset || asset == underlyingQuote);
+    int128 shapeCoef = ABDKMath64x64.div(shapeCoefNum, 1000);
+
+    uint256 underlyingBalance = IERC20(asset).balanceOf(bathTokenAddress);
+    require(
+      underlyingBalance > 0,
+      "no bathToken liquidity to calculate max orderSize permissable"
+    );
+
+    // if the asset/quote is overweighted: underlyingBalance / (Proportion of quote allocated to pair) * underlyingQuote balance
+    if (asset == underlyingAsset) {
+      int128 ratio = ABDKMath64x64.divu(
+        underlyingBalance,
+        IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+      );
+      if (ABDKMath64x64.mul(ratio, getMidpointPrice()) > (2**64)) {
+        // bid at maxSize
+        return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+      } else {
+        // return dynamic order size
+        uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+        int128 shapeFactor = ABDKMath64x64.exp(
+          ABDKMath64x64.mul(
+            shapeCoef,
+            ABDKMath64x64.inv(ABDKMath64x64.mul(ratio, getMidpointPrice()))
+          )
+        );
+        uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
+        return dynamicSize;
+      }
+    } else if (asset == underlyingQuote) {
+      int128 ratio = ABDKMath64x64.divu(
+        underlyingBalance,
+        IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+      );
+      if (ABDKMath64x64.div(ratio, getMidpointPrice()) > (2**64)) {
+        return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+      } else {
+        // return dynamic order size
+        uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+        int128 shapeFactor = ABDKMath64x64.exp(
+          ABDKMath64x64.mul(
+            shapeCoef,
+            ABDKMath64x64.inv(ABDKMath64x64.div(ratio, getMidpointPrice()))
+          )
+        );
+        uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
+        return dynamicSize;
+      }
+    }
+  }
+
+  // Used to map a strategist to their orders
+  function newTradeIDs(address strategist) internal {
+    require(
+      outstandingPairIDs[outstandingPairIDs.length - 1][2] == block.timestamp
+    );
+    IDs2strategist[
+      outstandingPairIDs[outstandingPairIDs.length - 1][0]
+    ] = strategist;
+    IDs2strategist[
+      outstandingPairIDs[outstandingPairIDs.length - 1][1]
+    ] = strategist;
+  }
+
+  function getLastTradeIDs() external view returns (uint256[3] memory) {
+    return outstandingPairIDs[outstandingPairIDs.length - 1];
+  }
+
+  // ** Below are the functions that can be called by Strategists **
+
+  function executeStrategy(
+    address targetStrategy,
+    uint256 askNumerator, // Quote / Asset
+    uint256 askDenominator, // Asset / Quote
+    uint256 bidNumerator, // size in ASSET
+    uint256 bidDenominator // size in QUOTES
+  )
+    external
+    onlyApprovedStrategy(targetStrategy)
+    enforceReserveRatio
+    onlyApprovedStrategist(msg.sender)
+  {
+    // Require at least one order is non-zero
+    require(
+      (askNumerator > 0 && askDenominator > 0) ||
+        (bidNumerator > 0 && bidDenominator > 0)
+    );
+
+    // Enforce dynamic ordersizing and inventory management
+    require(
+      askNumerator <= getMaxOrderSize(underlyingAsset, bathAssetAddress),
+      "ask too large"
+    );
+    require(
+      bidNumerator <= getMaxOrderSize(underlyingQuote, bathQuoteAddress),
+      "bid too large"
+    );
+
+    // Enforce that the bath is scrubbed for outstanding pairs
+    require(
+      outstandingPairIDs.length <
+        BathHouse(bathHouse).maxOutstandingPairCount(),
+      "too many outstanding pairs, please call bathScrub() first"
+    );
+
+    // 1. Enforce that a spread exists and that the ask price > best bid price && bid price < best ask price
+    enforceSpread(askNumerator, askDenominator, bidNumerator, bidDenominator);
+
+    // 2. Strategist executes a pair trade
+    IBidAskUtil(targetStrategy).execute(
+      underlyingAsset,
+      bathAssetAddress,
+      underlyingQuote,
+      bathQuoteAddress,
+      askNumerator, // ask pay_amt
+      askDenominator, // ask buy_amt
+      bidNumerator, // bid pay_amt
+      bidDenominator // bid buy_amt
+    );
+
+    // 3. Strategist trade is recorded so they can get paid and the trade is logged for time
+    // Need a mapping of trade ID that filled => strategist, timestamp, their price, bid or ask, midpoint price at that time
+    newTradeIDs(msg.sender);
+
+    emit LogStrategistTrades(
+      outstandingPairIDs[outstandingPairIDs.length - 1][0],
+      underlyingAsset,
+      outstandingPairIDs[outstandingPairIDs.length - 1][1],
+      underlyingQuote,
+      msg.sender,
+      block.timestamp
+    );
+
+    // 5. Return any filled yield to the appropriate bathToken/liquidity pool
+    rebalancePair();
+  }
+
+  // This function cleans outstanding orders and rebalances yield between bathTokens
+  function bathScrub() external {
+    // 4. Cancel Outstanding Orders that need to be cleared or logged for yield
+    cancelPartialFills();
+  }
+
+  // This function allows a strategist to remove Pools liquidity from the order book
+  function removeLiquidity(uint256 id) external {
+    require(
+      IDs2strategist[id] == msg.sender,
+      "only strategist can cancel their orders"
+    );
+    order memory ord = getOfferInfo(id);
+    if (ord.pay_gem == ERC20(underlyingAsset)) {
+      BathToken(bathAssetAddress).cancel(id);
+      for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
+        if (outstandingPairIDs[x][0] == id) {
+          removeElement(x);
+          break;
         }
-        if (fillCountQ > 0) {
-            uint256 booty = (
-                fillCountQ.mul(ERC20(underlyingQuote).balanceOf(address(this)))
-            )
-            .div(totalQuoteFills);
-            IERC20(underlyingQuote).transfer(msg.sender, booty);
-            totalQuoteFills -= fillCountQ;
+      }
+    } else if (ord.pay_gem == ERC20(underlyingQuote)) {
+      BathToken(bathQuoteAddress).cancel(id);
+      for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
+        if (outstandingPairIDs[x][1] == id) {
+          removeElement(x);
+          break;
         }
+      }
     }
-
-    function addOutstandingPair(uint256[3] calldata IDPair)
-        external
-        onlyApprovedStrategy(msg.sender)
-    {
-        require(IDPair.length == 3);
-        outstandingPairIDs.push(IDPair);
-    }
-
-    // orderID of the fill
-    // only log fills for each strategist - needs to be asset specific
-    // isAssetFill are *quotes* that result in asset yield
-    function logFill(uint256 orderID, bool isAssetFill) internal {
-        // Goal is to map a fill to a strategist
-        if (isAssetFill) {
-            strategist2FillsAsset[IDs2strategist[orderID]] += 1;
-            totalAssetFills += 1;
-        } else {
-            strategist2FillsQuote[IDs2strategist[orderID]] += 1;
-            totalQuoteFills += 1;
-        }
-    }
-
-    function removeElement(uint256 index) internal {
-        outstandingPairIDs[index] = outstandingPairIDs[
-            outstandingPairIDs.length - 1
-        ];
-        outstandingPairIDs.pop();
-    }
-
-    function cancelPartialFills() internal {
-        uint256 timeDelay = BathHouse(bathHouse).timeDelay();
-        uint256 len = outstandingPairIDs.length;
-        uint256 _start = start;
-
-        uint256 _searchRadius = searchRadius;
-        if (_start + _searchRadius >= len) {
-            // start over from beggining
-            if (_searchRadius >= len) {
-                _start = 0;
-                _searchRadius = len;
-            } else {
-                _searchRadius = len - _start;
-            }
-        }
-
-        for (uint256 x = _start; x < _start + _searchRadius; x++) {
-            if (outstandingPairIDs[x][2] < (block.timestamp - timeDelay)) {
-                uint256 askId = outstandingPairIDs[x][0];
-                uint256 bidId = outstandingPairIDs[x][1];
-                order memory offer1 = getOfferInfo(askId);
-                order memory offer2 = getOfferInfo(bidId);
-
-                // If Yield:
-                // getOfferInfo will make no yield recognizable on an empty offer by assigning pay_amt = 420;
-                if (offer1.pay_amt == 0 || offer2.pay_amt == 0) {
-                    //either is non zero
-                    //ask fills => check bid and handle
-                    if (offer1.pay_amt == 0) {
-                        logFill(askId, true);
-                        BathToken(bathAssetAddress).removeFilledTrade(askId);
-
-                        // if other order is non-zero, cancel
-                        if (offer2.pay_amt != 0 && offer2.pay_amt != 420) {
-                            BathToken(bathQuoteAddress).cancel(bidId);
-                            removeElement(x);
-                            x--;
-                            // len--;
-                            _searchRadius--;
-                            continue;
-                        }
-                    } else {
-                        logFill(bidId, false);
-                        BathToken(bathQuoteAddress).removeFilledTrade(bidId);
-
-                        // if other order is non-zero, cancel
-                        if (offer1.pay_amt != 0 && offer1.pay_amt != 420) {
-                            BathToken(bathAssetAddress).cancel(askId);
-                            removeElement(x);
-                            x--;
-                            // len--;
-                            _searchRadius--;
-                            continue;
-                        }
-                    }
-                } else {
-                    // If non-zero real order, cancel
-                    if (offer1.pay_amt != 0 && offer1.pay_amt != 420) {
-                        BathToken(bathAssetAddress).cancel(askId);
-                    }
-                    if (offer2.pay_amt != 0 && offer2.pay_amt != 420) {
-                        BathToken(bathQuoteAddress).cancel(bidId);
-                    }
-                    removeElement(x);
-                    x--;
-                    // len--;
-                    _searchRadius--;
-                }
-            }
-        }
-        if (_start + searchRadius >= len) {
-            start = 0;
-        } else {
-            start = _start + searchRadius;
-        }
-    }
-
-    // Get offer info from Rubicon Market
-    function getOfferInfo(uint256 id) internal view returns (order memory) {
-        if (id == 0) {
-            order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
-            return offerInfo;
-        } else {
-            (
-                uint256 ask_amt,
-                ERC20 ask_gem,
-                uint256 bid_amt,
-                ERC20 bid_gem
-            ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
-            order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
-            return offerInfo;
-        }
-    }
-
-    function getOutstandingPairCount() external view returns (uint256) {
-        return outstandingPairIDs.length;
-    }
-
-    function getSearchRadius() external view returns (uint256) {
-        return searchRadius;
-    }
-
-    // this throws on a zero value ofliquidity
-    function getMaxOrderSize(address asset, address bathTokenAddress)
-        public
-        view
-        returns (uint256 maxOrderSize)
-    {
-        require(asset == underlyingAsset || asset == underlyingQuote);
-        int128 shapeCoef = ABDKMath64x64.div(shapeCoefNum, 1000);
-
-        uint256 underlyingBalance = IERC20(asset).balanceOf(bathTokenAddress);
-        require(
-            underlyingBalance > 0,
-            "no bathToken liquidity to calculate max orderSize permissable"
-        );
-
-        // if the asset/quote is overweighted: underlyingBalance / (Proportion of quote allocated to pair) * underlyingQuote balance
-        if (asset == underlyingAsset) {
-            int128 ratio = ABDKMath64x64.divu(
-                underlyingBalance,
-                IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-            );
-            if (ABDKMath64x64.mul(ratio, getMidpointPrice()) > (2**64)) {
-                // bid at maxSize
-                return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-            } else {
-                // return dynamic order size
-                uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(
-                    10000
-                );
-                int128 shapeFactor = ABDKMath64x64.exp(
-                    ABDKMath64x64.mul(
-                        shapeCoef,
-                        ABDKMath64x64.inv(
-                            ABDKMath64x64.mul(ratio, getMidpointPrice())
-                        )
-                    )
-                );
-                uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
-                return dynamicSize;
-            }
-        } else if (asset == underlyingQuote) {
-            int128 ratio = ABDKMath64x64.divu(
-                underlyingBalance,
-                IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-            );
-            if (ABDKMath64x64.div(ratio, getMidpointPrice()) > (2**64)) {
-                return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-            } else {
-                // return dynamic order size
-                uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(
-                    10000
-                );
-                int128 shapeFactor = ABDKMath64x64.exp(
-                    ABDKMath64x64.mul(
-                        shapeCoef,
-                        ABDKMath64x64.inv(
-                            ABDKMath64x64.div(ratio, getMidpointPrice())
-                        )
-                    )
-                );
-                uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
-                return dynamicSize;
-            }
-        }
-    }
-
-    // Used to map a strategist to their orders
-    function newTradeIDs(address strategist) internal {
-        require(
-            outstandingPairIDs[outstandingPairIDs.length - 1][2] ==
-                block.timestamp
-        );
-        IDs2strategist[
-            outstandingPairIDs[outstandingPairIDs.length - 1][0]
-        ] = strategist;
-        IDs2strategist[
-            outstandingPairIDs[outstandingPairIDs.length - 1][1]
-        ] = strategist;
-    }
-
-    function getLastTradeIDs() external view returns (uint256[3] memory) {
-        return outstandingPairIDs[outstandingPairIDs.length - 1];
-    }
-
-    // ** Below are the functions that can be called by Strategists **
-
-    function executeStrategy(
-        address targetStrategy,
-        uint256 askNumerator, // Quote / Asset
-        uint256 askDenominator, // Asset / Quote
-        uint256 bidNumerator, // size in ASSET
-        uint256 bidDenominator // size in QUOTES
-    )
-        external
-        onlyApprovedStrategy(targetStrategy)
-        enforceReserveRatio
-        onlyApprovedStrategist(msg.sender)
-    {
-        // Require at least one order is non-zero
-        require(
-            (askNumerator > 0 && askDenominator > 0) ||
-                (bidNumerator > 0 && bidDenominator > 0)
-        );
-
-        // Enforce dynamic ordersizing and inventory management
-        require(
-            askNumerator <= getMaxOrderSize(underlyingAsset, bathAssetAddress),
-            "ask too large"
-        );
-        require(
-            bidNumerator <= getMaxOrderSize(underlyingQuote, bathQuoteAddress),
-            "bid too large"
-        );
-
-        // Enforce that the bath is scrubbed for outstanding pairs
-        require(
-            outstandingPairIDs.length <
-                BathHouse(bathHouse).maxOutstandingPairCount(),
-            "too many outstanding pairs, please call bathScrub() first"
-        );
-
-        // 1. Enforce that a spread exists and that the ask price > best bid price && bid price < best ask price
-        enforceSpread(
-            askNumerator,
-            askDenominator,
-            bidNumerator,
-            bidDenominator
-        );
-
-        // 2. Strategist executes a pair trade
-        IBidAskUtil(targetStrategy).execute(
-            underlyingAsset,
-            bathAssetAddress,
-            underlyingQuote,
-            bathQuoteAddress,
-            askNumerator, // ask pay_amt
-            askDenominator, // ask buy_amt
-            bidNumerator, // bid pay_amt
-            bidDenominator // bid buy_amt
-        );
-
-        // 3. Strategist trade is recorded so they can get paid and the trade is logged for time
-        // Need a mapping of trade ID that filled => strategist, timestamp, their price, bid or ask, midpoint price at that time
-        newTradeIDs(msg.sender);
-
-        emit LogStrategistTrades(
-            outstandingPairIDs[outstandingPairIDs.length - 1][0],
-            underlyingAsset,
-            outstandingPairIDs[outstandingPairIDs.length - 1][1],
-            underlyingQuote,
-            msg.sender,
-            block.timestamp
-        );
-
-        // 5. Return any filled yield to the appropriate bathToken/liquidity pool
-        rebalancePair();
-    }
-
-    // This function cleans outstanding orders and rebalances yield between bathTokens
-    function bathScrub() external {
-        // 4. Cancel Outstanding Orders that need to be cleared or logged for yield
-        cancelPartialFills();
-    }
-
-    // This function allows a strategist to remove Pools liquidity from the order book
-    function removeLiquidity(uint256 id) external {
-        require(
-            IDs2strategist[id] == msg.sender,
-            "only strategist can cancel their orders"
-        );
-        order memory ord = getOfferInfo(id);
-        if (ord.pay_gem == ERC20(underlyingAsset)) {
-            BathToken(bathAssetAddress).cancel(id);
-            for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-                if (outstandingPairIDs[x][0] == id) {
-                    removeElement(x);
-                    break;
-                }
-            }
-        } else if (ord.pay_gem == ERC20(underlyingQuote)) {
-            BathToken(bathQuoteAddress).cancel(id);
-            for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-                if (outstandingPairIDs[x][1] == id) {
-                    removeElement(x);
-                    break;
-                }
-            }
-        }
-    }
+  }
 }

--- a/contracts/rubiconPools/BathPair.sol
+++ b/contracts/rubiconPools/BathPair.sol
@@ -17,609 +17,633 @@ import "../interfaces/IBidAskUtil.sol";
 import "../peripheral_contracts/ABDKMath64x64.sol";
 
 contract BathPair {
-  using SafeMath for uint256;
+    using SafeMath for uint256;
 
-  address public bathHouse;
-  address public underlyingAsset;
-  address public underlyingQuote;
+    address public bathHouse;
+    address public underlyingAsset;
+    address public underlyingQuote;
 
-  address public bathAssetAddress;
-  address public bathQuoteAddress;
+    address public bathAssetAddress;
+    address public bathQuoteAddress;
 
-  address public RubiconMarketAddress;
+    address public RubiconMarketAddress;
 
-  bool public initialized;
+    bool public initialized;
 
-  int128 internal shapeCoefNum;
-  uint256 public maxOrderSizeBPS;
+    int128 internal shapeCoefNum;
+    uint256 public maxOrderSizeBPS;
 
-  /// @dev Internal variables for localalized searching in bathScrub
-  uint256 internal start;
-  uint256 internal searchRadius;
+    /// @dev Internal variables for localalized searching in bathScrub
+    uint256 internal start;
+    uint256 internal searchRadius;
 
-  uint256 internal totalAssetFills;
-  uint256 internal totalQuoteFills;
+    uint256 internal totalAssetFills;
+    uint256 internal totalQuoteFills;
 
-  /// @dev [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
-  uint256[5][] public outstandingPairIDs;
+    /// @dev [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+    uint256[5][] public outstandingPairIDs;
 
-  event LogNote(string, uint256, uint256);
-  event LogStrategistTrades(
-    uint256 idAsk,
-    address askAsset,
-    uint256 askAmt,
-    uint256 idBid,
-    address bidAsset,
-    uint256 bidAmt,
-    address strategist,
-    uint256 timestamp
-  );
-
-  /// @dev Maps a trade ID to each of their strategists for rewards purposes
-  mapping(uint256 => address) public IDs2strategist;
-  mapping(address => uint256) public strategist2FillsAsset;
-  mapping(address => uint256) public strategist2FillsQuote;
-
-  struct order {
-    uint256 pay_amt;
-    ERC20 pay_gem;
-    uint256 buy_amt;
-    ERC20 buy_gem;
-  }
-
-  /// @dev Proxy-safe initialization of storage
-  function initialize(
-    address _bathAssetAddress,
-    address _bathQuoteAddress,
-    address _bathHouse,
-    uint256 _maxOrderSizeBPS,
-    int128 _shapeCoefNum
-  ) external {
-    require(!initialized);
-    bathHouse = _bathHouse;
-
-    bathAssetAddress = _bathAssetAddress;
-    bathQuoteAddress = _bathQuoteAddress;
-
-    require(
-      BathToken(bathAssetAddress).underlying() !=
-        address(0x0000000000000000000000000000000000000000)
-    );
-    require(
-      BathToken(bathQuoteAddress).underlying() !=
-        address(0x0000000000000000000000000000000000000000)
-    );
-    underlyingAsset = BathToken(bathAssetAddress).underlying();
-    underlyingQuote = BathToken(bathQuoteAddress).underlying();
-
-    require(
-      BathHouse(bathHouse).getMarket() !=
-        address(0x0000000000000000000000000000000000000000)
-    );
-    RubiconMarketAddress = BathHouse(bathHouse).getMarket();
-
-    maxOrderSizeBPS = _maxOrderSizeBPS;
-    shapeCoefNum = _shapeCoefNum;
-    start = 0;
-    searchRadius = 3;
-    initialized = true;
-  }
-
-  modifier onlyBathHouse {
-    require(msg.sender == bathHouse);
-    _;
-  }
-
-  modifier onlyApprovedStrategy(address targetStrategy) {
-    require(
-      BathHouse(bathHouse).isApprovedStrat(targetStrategy) == true,
-      "not an approved strategy - bathPair"
-    );
-    _;
-  }
-
-  modifier onlyApprovedStrategist(address targetStrategist) {
-    require(
-      BathHouse(bathHouse).isApprovedStrategist(targetStrategist) == true,
-      "you are not an approved strategist - bathPair"
-    );
-    _;
-  }
-
-  modifier enforceReserveRatio {
-    require(
-      (
-        BathToken(bathAssetAddress).totalSupply().mul(
-          BathHouse(bathHouse).reserveRatio()
-        )
-      )
-      .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-    );
-    require(
-      (
-        BathToken(bathQuoteAddress).totalSupply().mul(
-          BathHouse(bathHouse).reserveRatio()
-        )
-      )
-      .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-    );
-    _;
-    require(
-      (
-        BathToken(bathAssetAddress).totalSupply().mul(
-          BathHouse(bathHouse).reserveRatio()
-        )
-      )
-      .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-    );
-    require(
-      (
-        BathToken(bathQuoteAddress).totalSupply().mul(
-          BathHouse(bathHouse).reserveRatio()
-        )
-      )
-      .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-    );
-  }
-
-  function setMaxOrderSizeBPS(uint16 val) external onlyBathHouse {
-    maxOrderSizeBPS = val;
-  }
-
-  function setShapeCoefNum(int128 val) external onlyBathHouse {
-    shapeCoefNum = val;
-  }
-
-  function setSearchRadius(uint256 val) external onlyBathHouse {
-    searchRadius = val;
-  }
-
-  function getMidpointPrice() internal view returns (int128) {
-    uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-      ERC20(underlyingAsset),
-      ERC20(underlyingQuote)
-    );
-    uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-      ERC20(underlyingQuote),
-      ERC20(underlyingAsset)
-    );
-    require(
-      bestAskID > 0 && bestBidID > 0,
-      "bids or asks are missing to get a Midpoint"
+    event LogNote(string, uint256, uint256);
+    event LogStrategistTrades(
+        uint256 idAsk,
+        address askAsset,
+        uint256 askAmt,
+        uint256 idBid,
+        address bidAsset,
+        uint256 bidAmt,
+        address strategist,
+        uint256 timestamp
     );
 
-    order memory bestAsk = getOfferInfo(bestAskID);
-    order memory bestBid = getOfferInfo(bestBidID);
-    int128 midpoint = ABDKMath64x64.divu(
-      (
-        (bestAsk.buy_amt.div(bestAsk.pay_amt)).add(
-          bestBid.pay_amt.div(bestBid.buy_amt)
-        )
-      ),
-      2
-    );
-    return midpoint;
-  }
+    /// @dev Maps a trade ID to each of their strategists for rewards purposes
+    mapping(uint256 => address) public IDs2strategist;
+    mapping(address => uint256) public strategist2FillsAsset;
+    mapping(address => uint256) public strategist2FillsQuote;
 
-  // Takes the proposed bid and ask as a parameter - that the offers placed won't match and are maker orders
-  // bid price > best ask
-  function enforceSpread(
-    uint256 askN,
-    uint256 askD,
-    uint256 bidN,
-    uint256 bidD
-  ) internal view {
-    require(
-      (askN > 0 && askD > 0) || (bidN > 0 && bidD > 0),
-      "one order must be non-zero"
-    );
+    struct order {
+        uint256 pay_amt;
+        ERC20 pay_gem;
+        uint256 buy_amt;
+        ERC20 buy_gem;
+    }
 
-    uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-      ERC20(underlyingAsset),
-      ERC20(underlyingQuote)
-    );
-    uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
-      ERC20(underlyingQuote),
-      ERC20(underlyingAsset)
-    );
+    /// @dev Proxy-safe initialization of storage
+    function initialize(
+        address _bathAssetAddress,
+        address _bathQuoteAddress,
+        address _bathHouse,
+        uint256 _maxOrderSizeBPS,
+        int128 _shapeCoefNum
+    ) external {
+        require(!initialized);
+        bathHouse = _bathHouse;
 
-    order memory bestAsk = getOfferInfo(bestAskID);
-    order memory bestBid = getOfferInfo(bestBidID);
+        bathAssetAddress = _bathAssetAddress;
+        bathQuoteAddress = _bathQuoteAddress;
 
-    // If orders in the order book, adhere to more constraints
-    if (
-      bestAsk.pay_amt > 0 &&
-      bestAsk.buy_amt > 0 &&
-      bestBid.pay_amt > 0 &&
-      bestBid.buy_amt > 0
-    ) {
-      if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
         require(
-          ((bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN))) &&
-            ((askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN))),
-          "bid must be < bestAsk && ask must be > best Bid in Price"
+            BathToken(bathAssetAddress).underlying() !=
+                address(0x0000000000000000000000000000000000000000)
         );
-      } else if (bidN > 0 && bidD > 0) {
-        // Goal is for (bestAsk.buy_amt / bestAsk.pay_amt) > (bidNumerator / bidDenominator)
         require(
-          (bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN)),
-          "bid price is not less than the best ask"
+            BathToken(bathQuoteAddress).underlying() !=
+                address(0x0000000000000000000000000000000000000000)
         );
-      } else if (askN > 0 && askD > 0) {
-        // Goal is for (askDenominator / askNumerator) > (bestBid.pay_amt / bestBid.buy_amt)
+        underlyingAsset = BathToken(bathAssetAddress).underlying();
+        underlyingQuote = BathToken(bathQuoteAddress).underlying();
+
         require(
-          (askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN)),
-          "ask price not greater than best bid"
+            BathHouse(bathHouse).getMarket() !=
+                address(0x0000000000000000000000000000000000000000)
         );
-      }
-    }
-    // check that ask price > bid price if two offers given
-    if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
-      require((askD.mul(bidD)) > (bidN.mul(askN)));
-    }
-  }
+        RubiconMarketAddress = BathHouse(bathHouse).getMarket();
 
-  function getThisBathQuote() external view returns (address) {
-    require(initialized);
-    return bathQuoteAddress;
-  }
-
-  function getThisBathAsset() external view returns (address) {
-    require(initialized);
-    return bathAssetAddress;
-  }
-
-  // Returns filled liquidity to the correct bath pool
-  function rebalancePair() internal {
-    uint256 bathAssetYield = ERC20(underlyingQuote).balanceOf(bathAssetAddress);
-    uint256 bathQuoteYield = ERC20(underlyingAsset).balanceOf(bathQuoteAddress);
-    uint16 stratReward = BathHouse(bathHouse).getBPSToStrats(address(this));
-    if (bathAssetYield > 0) {
-      BathToken(bathAssetAddress).rebalance(
-        bathQuoteAddress,
-        underlyingQuote,
-        stratReward
-      );
+        maxOrderSizeBPS = _maxOrderSizeBPS;
+        shapeCoefNum = _shapeCoefNum;
+        start = 0;
+        searchRadius = 3;
+        initialized = true;
     }
 
-    if (bathQuoteYield > 0) {
-      BathToken(bathQuoteAddress).rebalance(
-        bathAssetAddress,
-        underlyingAsset,
-        stratReward
-      );
-    }
-  }
-
-  // function where strategists claim rewards proportional to their quantity of fills
-  function strategistBootyClaim() external {
-    uint256 fillCountA = strategist2FillsAsset[msg.sender];
-    uint256 fillCountQ = strategist2FillsQuote[msg.sender];
-    if (fillCountA > 0) {
-      uint256 booty = (
-        fillCountA.mul(ERC20(underlyingAsset).balanceOf(address(this)))
-      )
-      .div(totalAssetFills);
-      IERC20(underlyingAsset).transfer(msg.sender, booty);
-      totalAssetFills -= fillCountA;
-    }
-    if (fillCountQ > 0) {
-      uint256 booty = (
-        fillCountQ.mul(ERC20(underlyingQuote).balanceOf(address(this)))
-      )
-      .div(totalQuoteFills);
-      IERC20(underlyingQuote).transfer(msg.sender, booty);
-      totalQuoteFills -= fillCountQ;
-    }
-  }
-
-  function addOutstandingPair(uint256[5] calldata IDPair)
-    external
-    onlyApprovedStrategy(msg.sender)
-  {
-    require(IDPair.length == 5);
-    outstandingPairIDs.push(IDPair);
-  }
-
-  // orderID of the fill
-  // only log fills for each strategist - needs to be asset specific
-  // isAssetFill are *quotes* that result in asset yield
-  function logFill(
-    uint256 amt,
-    uint256 orderID,
-    bool isAssetFill
-  ) internal {
-    // Goal is to map a fill to a strategist
-    if (isAssetFill) {
-      strategist2FillsAsset[IDs2strategist[orderID]] += amt;
-      totalAssetFills += amt;
-    } else {
-      strategist2FillsQuote[IDs2strategist[orderID]] += amt;
-      totalQuoteFills += amt;
-    }
-  }
-
-  function removeElement(uint256 index) internal {
-    outstandingPairIDs[index] = outstandingPairIDs[
-      outstandingPairIDs.length - 1
-    ];
-    outstandingPairIDs.pop();
-  }
-
-  function cancelPartialFills() internal {
-    uint256 timeDelay = BathHouse(bathHouse).timeDelay();
-    uint256 len = outstandingPairIDs.length;
-    uint256 _start = start;
-
-    uint256 _searchRadius = searchRadius;
-    if (_start + _searchRadius >= len) {
-      // start over from beggining
-      if (_searchRadius >= len) {
-        _start = 0;
-        _searchRadius = len;
-      } else {
-        _searchRadius = len - _start;
-      }
+    modifier onlyBathHouse {
+        require(msg.sender == bathHouse);
+        _;
     }
 
-    for (uint256 x = _start; x < _start + _searchRadius; x++) {
-      if (outstandingPairIDs[x][4] < (block.timestamp - timeDelay)) {
-        uint256 askId = outstandingPairIDs[x][0];
-        uint256 askAmt = outstandingPairIDs[x][1];
-        uint256 bidId = outstandingPairIDs[x][2];
-        uint256 bidAmt = outstandingPairIDs[x][3];
-        order memory offer1 = getOfferInfo(askId); //ask
-        order memory offer2 = getOfferInfo(bidId); //bid
-        uint256 askDelta = askAmt - offer1.pay_amt;
-        uint256 bidDelta = bidAmt - offer2.pay_amt;
+    modifier onlyApprovedStrategy(address targetStrategy) {
+        require(
+            BathHouse(bathHouse).isApprovedStrat(targetStrategy) == true,
+            "not an approved strategy - bathPair"
+        );
+        _;
+    }
 
-        // if real
-        if (askId != 0) {
-          // if delta > 0 - delta is fill => handle any amount of fill here
-          if (askDelta > 0) {
-            logFill(askDelta, askId, true); //todo make this accept an amount
-            BathToken(bathAssetAddress).removeFilledTradeAmount(askDelta);
-            // not a full fill
-            if (askDelta != askAmt) {
-              BathToken(bathAssetAddress).cancel(askId, askAmt);
+    modifier onlyApprovedStrategist(address targetStrategist) {
+        require(
+            BathHouse(bathHouse).isApprovedStrategist(targetStrategist) == true,
+            "you are not an approved strategist - bathPair"
+        );
+        _;
+    }
+
+    modifier enforceReserveRatio {
+        require(
+            (
+                BathToken(bathAssetAddress).totalSupply().mul(
+                    BathHouse(bathHouse).reserveRatio()
+                )
+            )
+            .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+        );
+        require(
+            (
+                BathToken(bathQuoteAddress).totalSupply().mul(
+                    BathHouse(bathHouse).reserveRatio()
+                )
+            )
+            .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+        );
+        _;
+        require(
+            (
+                BathToken(bathAssetAddress).totalSupply().mul(
+                    BathHouse(bathHouse).reserveRatio()
+                )
+            )
+            .div(100) <= IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+        );
+        require(
+            (
+                BathToken(bathQuoteAddress).totalSupply().mul(
+                    BathHouse(bathHouse).reserveRatio()
+                )
+            )
+            .div(100) <= IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+        );
+    }
+
+    function setMaxOrderSizeBPS(uint16 val) external onlyBathHouse {
+        maxOrderSizeBPS = val;
+    }
+
+    function setShapeCoefNum(int128 val) external onlyBathHouse {
+        shapeCoefNum = val;
+    }
+
+    function setSearchRadius(uint256 val) external onlyBathHouse {
+        searchRadius = val;
+    }
+
+    function getMidpointPrice() internal view returns (int128) {
+        uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+            ERC20(underlyingAsset),
+            ERC20(underlyingQuote)
+        );
+        uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+            ERC20(underlyingQuote),
+            ERC20(underlyingAsset)
+        );
+        require(
+            bestAskID > 0 && bestBidID > 0,
+            "bids or asks are missing to get a Midpoint"
+        );
+
+        order memory bestAsk = getOfferInfo(bestAskID);
+        order memory bestBid = getOfferInfo(bestBidID);
+        int128 midpoint = ABDKMath64x64.divu(
+            (
+                (bestAsk.buy_amt.div(bestAsk.pay_amt)).add(
+                    bestBid.pay_amt.div(bestBid.buy_amt)
+                )
+            ),
+            2
+        );
+        return midpoint;
+    }
+
+    // Takes the proposed bid and ask as a parameter - that the offers placed won't match and are maker orders
+    // bid price > best ask
+    function enforceSpread(
+        uint256 askN,
+        uint256 askD,
+        uint256 bidN,
+        uint256 bidD
+    ) internal view {
+        require(
+            (askN > 0 && askD > 0) || (bidN > 0 && bidD > 0),
+            "one order must be non-zero"
+        );
+
+        uint256 bestAskID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+            ERC20(underlyingAsset),
+            ERC20(underlyingQuote)
+        );
+        uint256 bestBidID = RubiconMarket(RubiconMarketAddress).getBestOffer(
+            ERC20(underlyingQuote),
+            ERC20(underlyingAsset)
+        );
+
+        order memory bestAsk = getOfferInfo(bestAskID);
+        order memory bestBid = getOfferInfo(bestBidID);
+
+        // If orders in the order book, adhere to more constraints
+        if (
+            bestAsk.pay_amt > 0 &&
+            bestAsk.buy_amt > 0 &&
+            bestBid.pay_amt > 0 &&
+            bestBid.buy_amt > 0
+        ) {
+            if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
+                require(
+                    ((bestAsk.buy_amt.mul(bidD)) >
+                        (bestAsk.pay_amt.mul(bidN))) &&
+                        ((askD.mul(bestBid.buy_amt)) >
+                            (bestBid.pay_amt.mul(askN))),
+                    "bid must be < bestAsk && ask must be > best Bid in Price"
+                );
+            } else if (bidN > 0 && bidD > 0) {
+                // Goal is for (bestAsk.buy_amt / bestAsk.pay_amt) > (bidNumerator / bidDenominator)
+                require(
+                    (bestAsk.buy_amt.mul(bidD)) > (bestAsk.pay_amt.mul(bidN)),
+                    "bid price is not less than the best ask"
+                );
+            } else if (askN > 0 && askD > 0) {
+                // Goal is for (askDenominator / askNumerator) > (bestBid.pay_amt / bestBid.buy_amt)
+                require(
+                    (askD.mul(bestBid.buy_amt)) > (bestBid.pay_amt.mul(askN)),
+                    "ask price not greater than best bid"
+                );
             }
-          }
-          // otherwise didn't fill so cancel
-          else {
-            BathToken(bathAssetAddress).cancel(askId, askAmt); // pas amount too
-          }
+        }
+        // check that ask price > bid price if two offers given
+        if (askN > 0 && askD > 0 && bidN > 0 && bidD > 0) {
+            require((askD.mul(bidD)) > (bidN.mul(askN)));
+        }
+    }
+
+    function getThisBathQuote() external view returns (address) {
+        require(initialized);
+        return bathQuoteAddress;
+    }
+
+    function getThisBathAsset() external view returns (address) {
+        require(initialized);
+        return bathAssetAddress;
+    }
+
+    // Returns filled liquidity to the correct bath pool
+    function rebalancePair() internal {
+        uint256 bathAssetYield = ERC20(underlyingQuote).balanceOf(
+            bathAssetAddress
+        );
+        uint256 bathQuoteYield = ERC20(underlyingAsset).balanceOf(
+            bathQuoteAddress
+        );
+        uint16 stratReward = BathHouse(bathHouse).getBPSToStrats(address(this));
+        if (bathAssetYield > 0) {
+            BathToken(bathAssetAddress).rebalance(
+                bathQuoteAddress,
+                underlyingQuote,
+                stratReward
+            );
         }
 
-        // if real
-        if (bidId != 0) {
-          // if delta > 0 - delta is fill => handle any amount of fill here
-          if (bidDelta > 0) {
-            logFill(bidDelta, bidId, false); //todo make this accept an amount
-            BathToken(bathQuoteAddress).removeFilledTradeAmount(bidDelta);
-            // not a full fill
-            if (bidDelta != bidAmt) {
-              BathToken(bathQuoteAddress).cancel(bidId, bidAmt);
+        if (bathQuoteYield > 0) {
+            BathToken(bathQuoteAddress).rebalance(
+                bathAssetAddress,
+                underlyingAsset,
+                stratReward
+            );
+        }
+    }
+
+    // function where strategists claim rewards proportional to their quantity of fills
+    function strategistBootyClaim() external {
+        uint256 fillCountA = strategist2FillsAsset[msg.sender];
+        uint256 fillCountQ = strategist2FillsQuote[msg.sender];
+        if (fillCountA > 0) {
+            uint256 booty = (
+                fillCountA.mul(ERC20(underlyingAsset).balanceOf(address(this)))
+            )
+            .div(totalAssetFills);
+            IERC20(underlyingAsset).transfer(msg.sender, booty);
+            totalAssetFills -= fillCountA;
+        }
+        if (fillCountQ > 0) {
+            uint256 booty = (
+                fillCountQ.mul(ERC20(underlyingQuote).balanceOf(address(this)))
+            )
+            .div(totalQuoteFills);
+            IERC20(underlyingQuote).transfer(msg.sender, booty);
+            totalQuoteFills -= fillCountQ;
+        }
+    }
+
+    function addOutstandingPair(uint256[5] calldata IDPair)
+        external
+        onlyApprovedStrategy(msg.sender)
+    {
+        require(IDPair.length == 5);
+        outstandingPairIDs.push(IDPair);
+    }
+
+    // orderID of the fill
+    // only log fills for each strategist - needs to be asset specific
+    // isAssetFill are *quotes* that result in asset yield
+    function logFill(
+        uint256 amt,
+        uint256 orderID,
+        bool isAssetFill
+    ) internal {
+        // Goal is to map a fill to a strategist
+        if (isAssetFill) {
+            strategist2FillsAsset[IDs2strategist[orderID]] += amt;
+            totalAssetFills += amt;
+        } else {
+            strategist2FillsQuote[IDs2strategist[orderID]] += amt;
+            totalQuoteFills += amt;
+        }
+    }
+
+    function removeElement(uint256 index) internal {
+        outstandingPairIDs[index] = outstandingPairIDs[
+            outstandingPairIDs.length - 1
+        ];
+        outstandingPairIDs.pop();
+    }
+
+    function cancelPartialFills() internal {
+        uint256 timeDelay = BathHouse(bathHouse).timeDelay();
+        uint256 len = outstandingPairIDs.length;
+        uint256 _start = start;
+
+        uint256 _searchRadius = searchRadius;
+        if (_start + _searchRadius >= len) {
+            // start over from beggining
+            if (_searchRadius >= len) {
+                _start = 0;
+                _searchRadius = len;
+            } else {
+                _searchRadius = len - _start;
             }
-          }
-          // otherwise didn't fill so cancel
-          else {
-            BathToken(bathQuoteAddress).cancel(bidId, bidAmt); // pas amount too
-          }
         }
 
-        removeElement(x);
-        x--;
-        _searchRadius--;
-      }
+        for (uint256 x = _start; x < _start + _searchRadius; x++) {
+            if (outstandingPairIDs[x][4] < (block.timestamp - timeDelay)) {
+                uint256 askId = outstandingPairIDs[x][0];
+                uint256 askAmt = outstandingPairIDs[x][1];
+                uint256 bidId = outstandingPairIDs[x][2];
+                uint256 bidAmt = outstandingPairIDs[x][3];
+                order memory offer1 = getOfferInfo(askId); //ask
+                order memory offer2 = getOfferInfo(bidId); //bid
+                uint256 askDelta = askAmt - offer1.pay_amt;
+                uint256 bidDelta = bidAmt - offer2.pay_amt;
+
+                // if real
+                if (askId != 0) {
+                    // if delta > 0 - delta is fill => handle any amount of fill here
+                    if (askDelta > 0) {
+                        logFill(askDelta, askId, true); //todo make this accept an amount
+                        BathToken(bathAssetAddress).removeFilledTradeAmount(
+                            askDelta
+                        );
+                        // not a full fill
+                        if (askDelta != askAmt) {
+                            BathToken(bathAssetAddress).cancel(askId, askAmt);
+                        }
+                    }
+                    // otherwise didn't fill so cancel
+                    else {
+                        BathToken(bathAssetAddress).cancel(askId, askAmt); // pas amount too
+                    }
+                }
+
+                // if real
+                if (bidId != 0) {
+                    // if delta > 0 - delta is fill => handle any amount of fill here
+                    if (bidDelta > 0) {
+                        logFill(bidDelta, bidId, false); //todo make this accept an amount
+                        BathToken(bathQuoteAddress).removeFilledTradeAmount(
+                            bidDelta
+                        );
+                        // not a full fill
+                        if (bidDelta != bidAmt) {
+                            BathToken(bathQuoteAddress).cancel(bidId, bidAmt);
+                        }
+                    }
+                    // otherwise didn't fill so cancel
+                    else {
+                        BathToken(bathQuoteAddress).cancel(bidId, bidAmt); // pas amount too
+                    }
+                }
+
+                removeElement(x);
+                x--;
+                _searchRadius--;
+            }
+        }
+        if (_start + searchRadius >= len) {
+            start = 0;
+        } else {
+            start = _start + searchRadius;
+        }
     }
-    if (_start + searchRadius >= len) {
-      start = 0;
-    } else {
-      start = _start + searchRadius;
+
+    // Get offer info from Rubicon Market
+    function getOfferInfo(uint256 id) internal view returns (order memory) {
+        if (id == 0) {
+            order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
+            return offerInfo;
+        } else {
+            (
+                uint256 ask_amt,
+                ERC20 ask_gem,
+                uint256 bid_amt,
+                ERC20 bid_gem
+            ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
+            order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
+            return offerInfo;
+        }
     }
-  }
 
-  // Get offer info from Rubicon Market
-  function getOfferInfo(uint256 id) internal view returns (order memory) {
-    if (id == 0) {
-      order memory offerInfo = order(420, ERC20(0), 69, ERC20(0));
-      return offerInfo;
-    } else {
-      (
-        uint256 ask_amt,
-        ERC20 ask_gem,
-        uint256 bid_amt,
-        ERC20 bid_gem
-      ) = RubiconMarket(RubiconMarketAddress).getOffer(id);
-      order memory offerInfo = order(ask_amt, ask_gem, bid_amt, bid_gem);
-      return offerInfo;
+    function getOutstandingPairCount() external view returns (uint256) {
+        return outstandingPairIDs.length;
     }
-  }
 
-  function getOutstandingPairCount() external view returns (uint256) {
-    return outstandingPairIDs.length;
-  }
+    function getSearchRadius() external view returns (uint256) {
+        return searchRadius;
+    }
 
-  function getSearchRadius() external view returns (uint256) {
-    return searchRadius;
-  }
+    // this throws on a zero value ofliquidity
+    function getMaxOrderSize(address asset, address bathTokenAddress)
+        public
+        view
+        returns (uint256 maxOrderSize)
+    {
+        require(asset == underlyingAsset || asset == underlyingQuote);
+        int128 shapeCoef = ABDKMath64x64.div(shapeCoefNum, 1000);
 
-  // this throws on a zero value ofliquidity
-  function getMaxOrderSize(address asset, address bathTokenAddress)
-    public
-    view
-    returns (uint256 maxOrderSize)
-  {
-    require(asset == underlyingAsset || asset == underlyingQuote);
-    int128 shapeCoef = ABDKMath64x64.div(shapeCoefNum, 1000);
-
-    uint256 underlyingBalance = IERC20(asset).balanceOf(bathTokenAddress);
-    require(
-      underlyingBalance > 0,
-      "no bathToken liquidity to calculate max orderSize permissable"
-    );
-
-    // if the asset/quote is overweighted: underlyingBalance / (Proportion of quote allocated to pair) * underlyingQuote balance
-    if (asset == underlyingAsset) {
-      int128 ratio = ABDKMath64x64.divu(
-        underlyingBalance,
-        IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
-      );
-      if (ABDKMath64x64.mul(ratio, getMidpointPrice()) > (2**64)) {
-        // bid at maxSize
-        return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-      } else {
-        // return dynamic order size
-        uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-        int128 shapeFactor = ABDKMath64x64.exp(
-          ABDKMath64x64.mul(
-            shapeCoef,
-            ABDKMath64x64.inv(ABDKMath64x64.mul(ratio, getMidpointPrice()))
-          )
+        uint256 underlyingBalance = IERC20(asset).balanceOf(bathTokenAddress);
+        require(
+            underlyingBalance > 0,
+            "no bathToken liquidity to calculate max orderSize permissable"
         );
-        uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
-        return dynamicSize;
-      }
-    } else if (asset == underlyingQuote) {
-      int128 ratio = ABDKMath64x64.divu(
-        underlyingBalance,
-        IERC20(underlyingAsset).balanceOf(bathAssetAddress)
-      );
-      if (ABDKMath64x64.div(ratio, getMidpointPrice()) > (2**64)) {
-        return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-      } else {
-        // return dynamic order size
-        uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(10000);
-        int128 shapeFactor = ABDKMath64x64.exp(
-          ABDKMath64x64.mul(
-            shapeCoef,
-            ABDKMath64x64.inv(ABDKMath64x64.div(ratio, getMidpointPrice()))
-          )
+
+        // if the asset/quote is overweighted: underlyingBalance / (Proportion of quote allocated to pair) * underlyingQuote balance
+        if (asset == underlyingAsset) {
+            int128 ratio = ABDKMath64x64.divu(
+                underlyingBalance,
+                IERC20(underlyingQuote).balanceOf(bathQuoteAddress)
+            );
+            if (ABDKMath64x64.mul(ratio, getMidpointPrice()) > (2**64)) {
+                // bid at maxSize
+                return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+            } else {
+                // return dynamic order size
+                uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(
+                    10000
+                );
+                int128 shapeFactor = ABDKMath64x64.exp(
+                    ABDKMath64x64.mul(
+                        shapeCoef,
+                        ABDKMath64x64.inv(
+                            ABDKMath64x64.mul(ratio, getMidpointPrice())
+                        )
+                    )
+                );
+                uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
+                return dynamicSize;
+            }
+        } else if (asset == underlyingQuote) {
+            int128 ratio = ABDKMath64x64.divu(
+                underlyingBalance,
+                IERC20(underlyingAsset).balanceOf(bathAssetAddress)
+            );
+            if (ABDKMath64x64.div(ratio, getMidpointPrice()) > (2**64)) {
+                return maxOrderSizeBPS.mul(underlyingBalance).div(10000);
+            } else {
+                // return dynamic order size
+                uint256 maxSize = maxOrderSizeBPS.mul(underlyingBalance).div(
+                    10000
+                );
+                int128 shapeFactor = ABDKMath64x64.exp(
+                    ABDKMath64x64.mul(
+                        shapeCoef,
+                        ABDKMath64x64.inv(
+                            ABDKMath64x64.div(ratio, getMidpointPrice())
+                        )
+                    )
+                );
+                uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
+                return dynamicSize;
+            }
+        }
+    }
+
+    // Used to map a strategist to their orders
+    function newTradeIDs(address strategist) internal {
+        require(
+            outstandingPairIDs[outstandingPairIDs.length - 1][4] ==
+                block.timestamp
         );
-        uint256 dynamicSize = ABDKMath64x64.mulu(shapeFactor, maxSize);
-        return dynamicSize;
-      }
+        IDs2strategist[
+            outstandingPairIDs[outstandingPairIDs.length - 1][0]
+        ] = strategist;
+        IDs2strategist[
+            outstandingPairIDs[outstandingPairIDs.length - 1][2]
+        ] = strategist;
     }
-  }
 
-  // Used to map a strategist to their orders
-  function newTradeIDs(address strategist) internal {
-    require(
-      outstandingPairIDs[outstandingPairIDs.length - 1][4] == block.timestamp
-    );
-    IDs2strategist[
-      outstandingPairIDs[outstandingPairIDs.length - 1][0]
-    ] = strategist;
-    IDs2strategist[
-      outstandingPairIDs[outstandingPairIDs.length - 1][2]
-    ] = strategist;
-  }
-
-  function getLastTradeIDs() external view returns (uint256[5] memory) {
-    return outstandingPairIDs[outstandingPairIDs.length - 1];
-  }
-
-  // ** Below are the functions that can be called by Strategists **
-
-  function executeStrategy(
-    address targetStrategy,
-    uint256 askNumerator, // Quote / Asset
-    uint256 askDenominator, // Asset / Quote
-    uint256 bidNumerator, // size in ASSET
-    uint256 bidDenominator // size in QUOTES
-  )
-    external
-    onlyApprovedStrategy(targetStrategy)
-    enforceReserveRatio
-    onlyApprovedStrategist(msg.sender)
-  {
-    // Require at least one order is non-zero
-    require(
-      (askNumerator > 0 && askDenominator > 0) ||
-        (bidNumerator > 0 && bidDenominator > 0)
-    );
-
-    // Enforce dynamic ordersizing and inventory management
-    require(
-      askNumerator <= getMaxOrderSize(underlyingAsset, bathAssetAddress),
-      "ask too large"
-    );
-    require(
-      bidNumerator <= getMaxOrderSize(underlyingQuote, bathQuoteAddress),
-      "bid too large"
-    );
-
-    // Enforce that the bath is scrubbed for outstanding pairs
-    require(
-      outstandingPairIDs.length <
-        BathHouse(bathHouse).maxOutstandingPairCount(),
-      "too many outstanding pairs, please call bathScrub() first"
-    );
-
-    // 1. Enforce that a spread exists and that the ask price > best bid price && bid price < best ask price
-    enforceSpread(askNumerator, askDenominator, bidNumerator, bidDenominator);
-
-    // 2. Strategist executes a pair trade
-    IBidAskUtil(targetStrategy).execute(
-      underlyingAsset,
-      bathAssetAddress,
-      underlyingQuote,
-      bathQuoteAddress,
-      askNumerator, // ask pay_amt
-      askDenominator, // ask buy_amt
-      bidNumerator, // bid pay_amt
-      bidDenominator // bid buy_amt
-    );
-
-    // 3. Strategist trade is recorded so they can get paid and the trade is logged for time
-    // Need a mapping of trade ID that filled => strategist, timestamp, their price, bid or ask, midpoint price at that time
-    newTradeIDs(msg.sender);
-
-    emit LogStrategistTrades(
-      outstandingPairIDs[outstandingPairIDs.length - 1][0],
-      underlyingAsset,
-      outstandingPairIDs[outstandingPairIDs.length - 1][1],
-      outstandingPairIDs[outstandingPairIDs.length - 1][2],
-      underlyingQuote,
-      outstandingPairIDs[outstandingPairIDs.length - 1][3],
-      msg.sender,
-      block.timestamp
-    );
-
-    // 5. Return any filled yield to the appropriate bathToken/liquidity pool
-    rebalancePair();
-  }
-
-  // This function cleans outstanding orders and rebalances yield between bathTokens
-  function bathScrub() external {
-    // 4. Cancel Outstanding Orders that need to be cleared or logged for yield
-    cancelPartialFills();
-  }
-
-  // This function allows a strategist to remove Pools liquidity from the order book
-  function removeLiquidity(uint256 id) external {
-    require(
-      IDs2strategist[id] == msg.sender,
-      "only strategist can cancel their orders"
-    );
-    // todo check for gas optimization
-    order memory ord = getOfferInfo(id);
-    if (ord.pay_gem == ERC20(underlyingAsset)) {
-      BathToken(bathAssetAddress).cancel(id, 0);
-      for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-        if (outstandingPairIDs[x][0] == id) {
-          removeElement(x);
-          break;
-        }
-      }
-    } else if (ord.pay_gem == ERC20(underlyingQuote)) {
-      BathToken(bathQuoteAddress).cancel(id, 0);
-      for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
-        if (outstandingPairIDs[x][2] == id) {
-          removeElement(x);
-          break;
-        }
-      }
+    function getLastTradeIDs() external view returns (uint256[5] memory) {
+        return outstandingPairIDs[outstandingPairIDs.length - 1];
     }
-  }
+
+    // ** Below are the functions that can be called by Strategists **
+
+    function executeStrategy(
+        address targetStrategy,
+        uint256 askNumerator, // Quote / Asset
+        uint256 askDenominator, // Asset / Quote
+        uint256 bidNumerator, // size in ASSET
+        uint256 bidDenominator // size in QUOTES
+    )
+        external
+        onlyApprovedStrategy(targetStrategy)
+        enforceReserveRatio
+        onlyApprovedStrategist(msg.sender)
+    {
+        // Require at least one order is non-zero
+        require(
+            (askNumerator > 0 && askDenominator > 0) ||
+                (bidNumerator > 0 && bidDenominator > 0)
+        );
+
+        // Enforce dynamic ordersizing and inventory management
+        require(
+            askNumerator <= getMaxOrderSize(underlyingAsset, bathAssetAddress),
+            "ask too large"
+        );
+        require(
+            bidNumerator <= getMaxOrderSize(underlyingQuote, bathQuoteAddress),
+            "bid too large"
+        );
+
+        // Enforce that the bath is scrubbed for outstanding pairs
+        require(
+            outstandingPairIDs.length <
+                BathHouse(bathHouse).maxOutstandingPairCount(),
+            "too many outstanding pairs, please call bathScrub() first"
+        );
+
+        // 1. Enforce that a spread exists and that the ask price > best bid price && bid price < best ask price
+        enforceSpread(
+            askNumerator,
+            askDenominator,
+            bidNumerator,
+            bidDenominator
+        );
+
+        // 2. Strategist executes a pair trade
+        IBidAskUtil(targetStrategy).execute(
+            underlyingAsset,
+            bathAssetAddress,
+            underlyingQuote,
+            bathQuoteAddress,
+            askNumerator, // ask pay_amt
+            askDenominator, // ask buy_amt
+            bidNumerator, // bid pay_amt
+            bidDenominator // bid buy_amt
+        );
+
+        // 3. Strategist trade is recorded so they can get paid and the trade is logged for time
+        // Need a mapping of trade ID that filled => strategist, timestamp, their price, bid or ask, midpoint price at that time
+        newTradeIDs(msg.sender);
+
+        emit LogStrategistTrades(
+            outstandingPairIDs[outstandingPairIDs.length - 1][0],
+            underlyingAsset,
+            outstandingPairIDs[outstandingPairIDs.length - 1][1],
+            outstandingPairIDs[outstandingPairIDs.length - 1][2],
+            underlyingQuote,
+            outstandingPairIDs[outstandingPairIDs.length - 1][3],
+            msg.sender,
+            block.timestamp
+        );
+
+        // 5. Return any filled yield to the appropriate bathToken/liquidity pool
+        rebalancePair();
+    }
+
+    // This function cleans outstanding orders and rebalances yield between bathTokens
+    function bathScrub() external {
+        // 4. Cancel Outstanding Orders that need to be cleared or logged for yield
+        cancelPartialFills();
+    }
+
+    // This function allows a strategist to remove Pools liquidity from the order book
+    function removeLiquidity(uint256 id) external {
+        require(
+            IDs2strategist[id] == msg.sender,
+            "only strategist can cancel their orders"
+        );
+        // todo check for gas optimization
+        order memory ord = getOfferInfo(id);
+        if (ord.pay_gem == ERC20(underlyingAsset)) {
+            BathToken(bathAssetAddress).cancel(id, 0);
+            for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
+                if (outstandingPairIDs[x][0] == id) {
+                    removeElement(x);
+                    break;
+                }
+            }
+        } else if (ord.pay_gem == ERC20(underlyingQuote)) {
+            BathToken(bathQuoteAddress).cancel(id, 0);
+            for (uint256 x = 0; x < outstandingPairIDs.length; x++) {
+                if (outstandingPairIDs[x][2] == id) {
+                    removeElement(x);
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -14,322 +14,314 @@ import "./BidAskUtil.sol";
 import "./BathHouse.sol";
 
 contract BathToken {
-    using SafeMath for uint256;
-    bool public initialized;
+  using SafeMath for uint256;
+  bool public initialized;
 
-    string public symbol;
-    string public name;
-    uint8 public decimals;
+  string public symbol;
+  string public name;
+  uint8 public decimals;
 
-    address public RubiconMarketAddress;
-    address public bathHouse; // admin
-    address public feeTo;
-    IERC20 public underlyingToken;
-    uint256 public feeBPS;
+  address public RubiconMarketAddress;
+  address public bathHouse; // admin
+  address public feeTo;
+  IERC20 public underlyingToken;
+  uint256 public feeBPS;
 
-    uint256 public totalSupply;
-    uint256 public outstandingAmount; // quantity of underlyingToken that is in the orderbook and still in pools
-    uint256[] outstandingIDs;
-    mapping(uint256 => uint256) id2Ind;
+  uint256 public totalSupply;
+  uint256 public outstandingAmount; // quantity of underlyingToken that is in the orderbook and still in pools
+  uint256[] outstandingIDs;
+  mapping(uint256 => uint256) id2Ind;
 
-    mapping(address => uint256) public balanceOf;
-    mapping(address => mapping(address => uint256)) public allowance;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
 
-    bytes32 public DOMAIN_SEPARATOR;
-    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 public constant PERMIT_TYPEHASH =
-        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
-    mapping(address => uint256) public nonces;
+  bytes32 public DOMAIN_SEPARATOR;
+  // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+  bytes32 public constant PERMIT_TYPEHASH =
+    0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+  mapping(address => uint256) public nonces;
 
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        uint256 value
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event LogTrade(
+    uint256 pay_amt,
+    ERC20 pay_gem,
+    uint256 buy_amt,
+    ERC20 buy_gem
+  );
+  event LogInit(uint256 timeOfInit);
+
+  /// @dev Proxy-safe initialization of storage
+  function initialize(
+    string memory bathName,
+    IERC20 token,
+    address market,
+    address _bathHouse,
+    address _feeTo
+  ) external {
+    require(!initialized);
+    symbol = bathName;
+    underlyingToken = token;
+    RubiconMarketAddress = market;
+    bathHouse = _bathHouse;
+
+    uint256 chainId;
+    assembly {
+      chainId := chainid()
+    }
+    DOMAIN_SEPARATOR = keccak256(
+      abi.encode(
+        keccak256(
+          "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        ),
+        keccak256(bytes(name)),
+        keccak256(bytes("1")),
+        chainId,
+        address(this)
+      )
     );
-    event Transfer(address indexed from, address indexed to, uint256 value);
-    event LogTrade(
-        uint256 pay_amt,
-        ERC20 pay_gem,
-        uint256 buy_amt,
-        ERC20 buy_gem
+    name = "BathToken v1";
+    decimals = 18;
+
+    require(
+      RubiconMarket(RubiconMarketAddress).initialized() &&
+        BathHouse(bathHouse).initialized()
     );
-    event LogInit(uint256 timeOfInit);
 
-    /// @dev Proxy-safe initialization of storage
-    function initialize(
-        string memory bathName,
-        IERC20 token,
-        address market,
-        address _bathHouse,
-        address _feeTo
-    ) external {
-        require(!initialized);
-        symbol = bathName;
-        underlyingToken = token;
-        RubiconMarketAddress = market;
-        bathHouse = _bathHouse;
+    // Add infinite approval of Rubicon Market for this asset
 
-        uint256 chainId;
-        assembly {
-            chainId := chainid()
-        }
-        DOMAIN_SEPARATOR = keccak256(
-            abi.encode(
-                keccak256(
-                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-                ),
-                keccak256(bytes(name)),
-                keccak256(bytes("1")),
-                chainId,
-                address(this)
-            )
-        );
-        name = "BathToken v1";
-        decimals = 18;
+    IERC20(address(token)).approve(RubiconMarketAddress, 2**256 - 1);
+    emit LogInit(block.timestamp);
 
-        require(
-            RubiconMarket(RubiconMarketAddress).initialized() &&
-                BathHouse(bathHouse).initialized()
-        );
+    feeTo = _feeTo; //BathHouse admin is initial recipient
+    feeBPS = 0; //Fee set to zero
 
-        // Add infinite approval of Rubicon Market for this asset
+    initialized = true;
+  }
 
-        IERC20(address(token)).approve(RubiconMarketAddress, 2**256 - 1);
-        emit LogInit(block.timestamp);
+  modifier onlyPair {
+    require(
+      BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
+      "not an approved pair - bathToken"
+    );
+    _;
+  }
 
-        feeTo = _feeTo; //BathHouse admin is initial recipient
-        feeBPS = 0; //Fee set to zero
+  modifier onlyApprovedStrategy() {
+    require(
+      BathHouse(bathHouse).isApprovedStrat(msg.sender) == true,
+      "not an approved strategy - bathToken"
+    );
+    _;
+  }
 
-        initialized = true;
+  function setMarket(address newRubiconMarket) external {
+    require(msg.sender == bathHouse && initialized);
+    RubiconMarketAddress = newRubiconMarket;
+  }
+
+  function setBathHouse(address newBathHouse) external {
+    require(msg.sender == bathHouse && initialized);
+    bathHouse = newBathHouse;
+  }
+
+  function setFeeBPS(uint256 _feeBPS) external {
+    require(msg.sender == bathHouse && initialized);
+    feeBPS = _feeBPS;
+  }
+
+  function setFeeTo(address _feeTo) external {
+    require(msg.sender == bathHouse && initialized);
+    feeTo = _feeTo;
+  }
+
+  // Rubicon Market Functions:
+  // pass initAmt as zero if unsure
+  function cancel(uint256 id, uint256 initAmt) external onlyPair {
+    if (initAmt == 0) {
+      (uint256 pay_amt, , , ) = RubiconMarket(RubiconMarketAddress).getOffer(
+        id
+      );
+      outstandingAmount = outstandingAmount.sub(pay_amt);
+    } else {
+      outstandingAmount = outstandingAmount.sub(initAmt);
     }
+    RubiconMarket(RubiconMarketAddress).cancel(id);
+  }
 
-    modifier onlyPair {
-        require(
-            BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
-            "not an approved pair - bathToken"
-        );
-        _;
+  function removeFilledTradeAmount(uint256 amt) external onlyPair {
+    outstandingAmount = outstandingAmount.sub(amt);
+  }
+
+  // function that places a bid/ask in the orderbook for a given pair
+  function placeOffer(
+    uint256 pay_amt,
+    ERC20 pay_gem,
+    uint256 buy_amt,
+    ERC20 buy_gem
+  ) external onlyApprovedStrategy returns (uint256) {
+    // Place an offer in RubiconMarket
+    // The below ensures that the order does not automatically match/become a taker trade **enforceNoAutoFills**
+    // while also ensuring that the order is placed in the sorted list
+    uint256 id = RubiconMarket(RubiconMarketAddress).offer(
+      pay_amt,
+      pay_gem,
+      buy_amt,
+      buy_gem,
+      0,
+      false
+    );
+    outstandingAmount = outstandingAmount.add(pay_amt);
+    return (id);
+  }
+
+  function underlying() external view returns (address) {
+    require(initialized);
+    return address(underlyingToken);
+  }
+
+  /// @notice returns the amount of underlying ERC20 tokens in this pool in addition to
+  ///         any tokens that may be outstanding in the Rubicon order book
+  function underlyingBalance() public view returns (uint256) {
+    require(initialized, "BathToken not initialized");
+
+    uint256 _pool = IERC20(underlyingToken).balanceOf(address(this));
+    return _pool.add(outstandingAmount);
+  }
+
+  // https://github.com/yearn/yearn-protocol/blob/develop/contracts/vaults/yVault.sol - shoutout yEarn homies
+  function deposit(uint256 _amount) external {
+    uint256 _pool = underlyingBalance();
+    uint256 _before = underlyingToken.balanceOf(address(this));
+
+    underlyingToken.transferFrom(msg.sender, address(this), _amount);
+    uint256 _after = underlyingToken.balanceOf(address(this));
+    _amount = _after.sub(_before); // Additional check for deflationary tokens
+
+    uint256 shares = 0;
+    if (totalSupply == 0) {
+      shares = _amount;
+    } else {
+      shares = (_amount.mul(totalSupply)).div(_pool);
     }
+    _mint(msg.sender, shares);
+  }
 
-    modifier onlyApprovedStrategy() {
-        require(
-            BathHouse(bathHouse).isApprovedStrat(msg.sender) == true,
-            "not an approved strategy - bathToken"
-        );
-        _;
+  // No rebalance implementation for lower fees and faster swaps
+  function withdraw(uint256 _shares) external {
+    uint256 r = (underlyingBalance().mul(_shares)).div(totalSupply);
+    _burn(msg.sender, _shares);
+
+    uint256 _fee = r.mul(feeBPS).div(10000);
+    IERC20(underlyingToken).transfer(feeTo, _fee);
+
+    underlyingToken.transfer(msg.sender, r.sub(_fee));
+  }
+
+  // This function returns filled orders to the correct liquidity pool and sends strategist rewards to the Pair
+  function rebalance(
+    address sisterBath,
+    address underlyingAsset, /* sister asset */
+    uint256 stratProportion
+  ) external onlyPair {
+    require(stratProportion > 0 && stratProportion < 50 && initialized);
+    uint256 stratReward = (
+      stratProportion.mul(IERC20(underlyingAsset).balanceOf(address(this)))
+    )
+    .div(10000);
+    IERC20(underlyingAsset).transfer(
+      sisterBath,
+      IERC20(underlyingAsset).balanceOf(address(this)).sub(stratReward)
+    );
+    IERC20(underlyingAsset).transfer(msg.sender, stratReward);
+  }
+
+  // *** Internal Functions ***
+
+  function _mint(address to, uint256 value) internal {
+    totalSupply = totalSupply.add(value);
+    balanceOf[to] = balanceOf[to].add(value);
+    emit Transfer(address(0), to, value);
+  }
+
+  function _burn(address from, uint256 value) internal {
+    balanceOf[from] = balanceOf[from].sub(value);
+    totalSupply = totalSupply.sub(value);
+    emit Transfer(from, address(0), value);
+  }
+
+  function _approve(
+    address owner,
+    address spender,
+    uint256 value
+  ) private {
+    allowance[owner][spender] = value;
+    emit Approval(owner, spender, value);
+  }
+
+  function _transfer(
+    address from,
+    address to,
+    uint256 value
+  ) private {
+    balanceOf[from] = balanceOf[from].sub(value);
+    balanceOf[to] = balanceOf[to].add(value);
+    emit Transfer(from, to, value);
+  }
+
+  function approve(address spender, uint256 value) external returns (bool) {
+    _approve(msg.sender, spender, value);
+    return true;
+  }
+
+  function transfer(address to, uint256 value) external returns (bool) {
+    _transfer(msg.sender, to, value);
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 value
+  ) external returns (bool) {
+    if (allowance[from][msg.sender] != uint256(-1)) {
+      allowance[from][msg.sender] = allowance[from][msg.sender].sub(value);
     }
+    _transfer(from, to, value);
+    return true;
+  }
 
-    function setMarket(address newRubiconMarket) external {
-        require(msg.sender == bathHouse && initialized);
-        RubiconMarketAddress = newRubiconMarket;
-    }
-
-    function setBathHouse(address newBathHouse) external {
-        require(msg.sender == bathHouse && initialized);
-        bathHouse = newBathHouse;
-    }
-
-    function setFeeBPS(uint256 _feeBPS) external {
-        require(msg.sender == bathHouse && initialized);
-        feeBPS = _feeBPS;
-    }
-
-    function setFeeTo(address _feeTo) external {
-        require(msg.sender == bathHouse && initialized);
-        feeTo = _feeTo;
-    }
-
-    // Rubicon Market Functions:
-
-    function cancel(uint256 id) external onlyPair {
-        (uint256 pay_amt, , , ) = RubiconMarket(RubiconMarketAddress).getOffer(
-            id
-        );
-        outstandingAmount = outstandingAmount.sub(pay_amt);
-
-        RubiconMarket(RubiconMarketAddress).cancel(id);
-    }
-
-    function removeFilledTrade(uint256 id) external onlyPair {
-        (uint256 pay_amt, , , ) = RubiconMarket(RubiconMarketAddress).getOffer(
-            id
-        );
-        outstandingAmount = outstandingAmount.sub(pay_amt);
-    }
-
-    // function that places a bid/ask in the orderbook for a given pair
-    function placeOffer(
-        uint256 pay_amt,
-        ERC20 pay_gem,
-        uint256 buy_amt,
-        ERC20 buy_gem
-    ) external onlyApprovedStrategy returns (uint256) {
-        // Place an offer in RubiconMarket
-        // The below ensures that the order does not automatically match/become a taker trade **enforceNoAutoFills**
-        // while also ensuring that the order is placed in the sorted list
-        uint256 id = RubiconMarket(RubiconMarketAddress).offer(
-            pay_amt,
-            pay_gem,
-            buy_amt,
-            buy_gem,
-            0,
-            false
-        );
-        outstandingAmount = outstandingAmount.add(pay_amt);
-        return (id);
-    }
-
-    function underlying() external view returns (address) {
-        require(initialized);
-        return address(underlyingToken);
-    }
-
-    /// @notice returns the amount of underlying ERC20 tokens in this pool in addition to
-    ///         any tokens that may be outstanding in the Rubicon order book
-    function underlyingBalance() public view returns (uint256) {
-        require(initialized, "BathToken not initialized");
-
-        uint256 _pool = IERC20(underlyingToken).balanceOf(address(this));
-        return _pool.add(outstandingAmount);
-    }
-
-    // https://github.com/yearn/yearn-protocol/blob/develop/contracts/vaults/yVault.sol - shoutout yEarn homies
-    function deposit(uint256 _amount) external {
-        uint256 _pool = underlyingBalance();
-        uint256 _before = underlyingToken.balanceOf(address(this));
-
-        underlyingToken.transferFrom(msg.sender, address(this), _amount);
-        uint256 _after = underlyingToken.balanceOf(address(this));
-        _amount = _after.sub(_before); // Additional check for deflationary tokens
-
-        uint256 shares = 0;
-        if (totalSupply == 0) {
-            shares = _amount;
-        } else {
-            shares = (_amount.mul(totalSupply)).div(_pool);
-        }
-        _mint(msg.sender, shares);
-    }
-
-    // No rebalance implementation for lower fees and faster swaps
-    function withdraw(uint256 _shares) external {
-        uint256 r = (underlyingBalance().mul(_shares)).div(totalSupply);
-        _burn(msg.sender, _shares);
-
-        uint256 _fee = r.mul(feeBPS).div(10000);
-        IERC20(underlyingToken).transfer(feeTo, _fee);
-
-        underlyingToken.transfer(msg.sender, r.sub(_fee));
-    }
-
-    // This function returns filled orders to the correct liquidity pool and sends strategist rewards to the Pair
-    function rebalance(
-        address sisterBath,
-        address underlyingAsset, /* sister asset */
-        uint256 stratProportion
-    ) external onlyPair {
-        require(stratProportion > 0 && stratProportion < 50 && initialized);
-        uint256 stratReward = (
-            stratProportion.mul(
-                IERC20(underlyingAsset).balanceOf(address(this))
-            )
+  function permit(
+    address owner,
+    address spender,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external {
+    require(deadline >= block.timestamp, "bathToken: EXPIRED");
+    bytes32 digest = keccak256(
+      abi.encodePacked(
+        "\x19\x01",
+        DOMAIN_SEPARATOR,
+        keccak256(
+          abi.encode(
+            PERMIT_TYPEHASH,
+            owner,
+            spender,
+            value,
+            nonces[owner]++,
+            deadline
+          )
         )
-        .div(10000);
-        IERC20(underlyingAsset).transfer(
-            sisterBath,
-            IERC20(underlyingAsset).balanceOf(address(this)).sub(stratReward)
-        );
-        IERC20(underlyingAsset).transfer(msg.sender, stratReward);
-    }
-
-    // *** Internal Functions ***
-
-    function _mint(address to, uint256 value) internal {
-        totalSupply = totalSupply.add(value);
-        balanceOf[to] = balanceOf[to].add(value);
-        emit Transfer(address(0), to, value);
-    }
-
-    function _burn(address from, uint256 value) internal {
-        balanceOf[from] = balanceOf[from].sub(value);
-        totalSupply = totalSupply.sub(value);
-        emit Transfer(from, address(0), value);
-    }
-
-    function _approve(
-        address owner,
-        address spender,
-        uint256 value
-    ) private {
-        allowance[owner][spender] = value;
-        emit Approval(owner, spender, value);
-    }
-
-    function _transfer(
-        address from,
-        address to,
-        uint256 value
-    ) private {
-        balanceOf[from] = balanceOf[from].sub(value);
-        balanceOf[to] = balanceOf[to].add(value);
-        emit Transfer(from, to, value);
-    }
-
-    function approve(address spender, uint256 value) external returns (bool) {
-        _approve(msg.sender, spender, value);
-        return true;
-    }
-
-    function transfer(address to, uint256 value) external returns (bool) {
-        _transfer(msg.sender, to, value);
-        return true;
-    }
-
-    function transferFrom(
-        address from,
-        address to,
-        uint256 value
-    ) external returns (bool) {
-        if (allowance[from][msg.sender] != uint256(-1)) {
-            allowance[from][msg.sender] = allowance[from][msg.sender].sub(
-                value
-            );
-        }
-        _transfer(from, to, value);
-        return true;
-    }
-
-    function permit(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external {
-        require(deadline >= block.timestamp, "bathToken: EXPIRED");
-        bytes32 digest = keccak256(
-            abi.encodePacked(
-                "\x19\x01",
-                DOMAIN_SEPARATOR,
-                keccak256(
-                    abi.encode(
-                        PERMIT_TYPEHASH,
-                        owner,
-                        spender,
-                        value,
-                        nonces[owner]++,
-                        deadline
-                    )
-                )
-            )
-        );
-        address recoveredAddress = ecrecover(digest, v, r, s);
-        require(
-            recoveredAddress != address(0) && recoveredAddress == owner,
-            "bathToken: INVALID_SIGNATURE"
-        );
-        _approve(owner, spender, value);
-    }
+      )
+    );
+    address recoveredAddress = ecrecover(digest, v, r, s);
+    require(
+      recoveredAddress != address(0) && recoveredAddress == owner,
+      "bathToken: INVALID_SIGNATURE"
+    );
+    _approve(owner, spender, value);
+  }
 }

--- a/contracts/rubiconPools/BathToken.sol
+++ b/contracts/rubiconPools/BathToken.sol
@@ -14,314 +14,321 @@ import "./BidAskUtil.sol";
 import "./BathHouse.sol";
 
 contract BathToken {
-  using SafeMath for uint256;
-  bool public initialized;
+    using SafeMath for uint256;
+    bool public initialized;
 
-  string public symbol;
-  string public name;
-  uint8 public decimals;
+    string public symbol;
+    string public name;
+    uint8 public decimals;
 
-  address public RubiconMarketAddress;
-  address public bathHouse; // admin
-  address public feeTo;
-  IERC20 public underlyingToken;
-  uint256 public feeBPS;
+    address public RubiconMarketAddress;
+    address public bathHouse; // admin
+    address public feeTo;
+    IERC20 public underlyingToken;
+    uint256 public feeBPS;
 
-  uint256 public totalSupply;
-  uint256 public outstandingAmount; // quantity of underlyingToken that is in the orderbook and still in pools
-  uint256[] outstandingIDs;
-  mapping(uint256 => uint256) id2Ind;
+    uint256 public totalSupply;
+    uint256 public outstandingAmount; // quantity of underlyingToken that is in the orderbook and still in pools
+    uint256[] outstandingIDs;
+    mapping(uint256 => uint256) id2Ind;
 
-  mapping(address => uint256) public balanceOf;
-  mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
 
-  bytes32 public DOMAIN_SEPARATOR;
-  // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-  bytes32 public constant PERMIT_TYPEHASH =
-    0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
-  mapping(address => uint256) public nonces;
+    bytes32 public DOMAIN_SEPARATOR;
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    mapping(address => uint256) public nonces;
 
-  event Approval(address indexed owner, address indexed spender, uint256 value);
-  event Transfer(address indexed from, address indexed to, uint256 value);
-  event LogTrade(
-    uint256 pay_amt,
-    ERC20 pay_gem,
-    uint256 buy_amt,
-    ERC20 buy_gem
-  );
-  event LogInit(uint256 timeOfInit);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event LogTrade(
+        uint256 pay_amt,
+        ERC20 pay_gem,
+        uint256 buy_amt,
+        ERC20 buy_gem
+    );
+    event LogInit(uint256 timeOfInit);
 
-  /// @dev Proxy-safe initialization of storage
-  function initialize(
-    string memory bathName,
-    IERC20 token,
-    address market,
-    address _bathHouse,
-    address _feeTo
-  ) external {
-    require(!initialized);
-    symbol = bathName;
-    underlyingToken = token;
-    RubiconMarketAddress = market;
-    bathHouse = _bathHouse;
+    /// @dev Proxy-safe initialization of storage
+    function initialize(
+        string memory bathName,
+        IERC20 token,
+        address market,
+        address _bathHouse,
+        address _feeTo
+    ) external {
+        require(!initialized);
+        symbol = bathName;
+        underlyingToken = token;
+        RubiconMarketAddress = market;
+        bathHouse = _bathHouse;
 
-    uint256 chainId;
-    assembly {
-      chainId := chainid()
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(name)),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+        name = "BathToken v1";
+        decimals = 18;
+
+        require(
+            RubiconMarket(RubiconMarketAddress).initialized() &&
+                BathHouse(bathHouse).initialized()
+        );
+
+        // Add infinite approval of Rubicon Market for this asset
+
+        IERC20(address(token)).approve(RubiconMarketAddress, 2**256 - 1);
+        emit LogInit(block.timestamp);
+
+        feeTo = _feeTo; //BathHouse admin is initial recipient
+        feeBPS = 0; //Fee set to zero
+
+        initialized = true;
     }
-    DOMAIN_SEPARATOR = keccak256(
-      abi.encode(
-        keccak256(
-          "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-        ),
-        keccak256(bytes(name)),
-        keccak256(bytes("1")),
-        chainId,
-        address(this)
-      )
-    );
-    name = "BathToken v1";
-    decimals = 18;
 
-    require(
-      RubiconMarket(RubiconMarketAddress).initialized() &&
-        BathHouse(bathHouse).initialized()
-    );
-
-    // Add infinite approval of Rubicon Market for this asset
-
-    IERC20(address(token)).approve(RubiconMarketAddress, 2**256 - 1);
-    emit LogInit(block.timestamp);
-
-    feeTo = _feeTo; //BathHouse admin is initial recipient
-    feeBPS = 0; //Fee set to zero
-
-    initialized = true;
-  }
-
-  modifier onlyPair {
-    require(
-      BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
-      "not an approved pair - bathToken"
-    );
-    _;
-  }
-
-  modifier onlyApprovedStrategy() {
-    require(
-      BathHouse(bathHouse).isApprovedStrat(msg.sender) == true,
-      "not an approved strategy - bathToken"
-    );
-    _;
-  }
-
-  function setMarket(address newRubiconMarket) external {
-    require(msg.sender == bathHouse && initialized);
-    RubiconMarketAddress = newRubiconMarket;
-  }
-
-  function setBathHouse(address newBathHouse) external {
-    require(msg.sender == bathHouse && initialized);
-    bathHouse = newBathHouse;
-  }
-
-  function setFeeBPS(uint256 _feeBPS) external {
-    require(msg.sender == bathHouse && initialized);
-    feeBPS = _feeBPS;
-  }
-
-  function setFeeTo(address _feeTo) external {
-    require(msg.sender == bathHouse && initialized);
-    feeTo = _feeTo;
-  }
-
-  // Rubicon Market Functions:
-  // pass initAmt as zero if unsure
-  function cancel(uint256 id, uint256 initAmt) external onlyPair {
-    if (initAmt == 0) {
-      (uint256 pay_amt, , , ) = RubiconMarket(RubiconMarketAddress).getOffer(
-        id
-      );
-      outstandingAmount = outstandingAmount.sub(pay_amt);
-    } else {
-      outstandingAmount = outstandingAmount.sub(initAmt);
+    modifier onlyPair {
+        require(
+            BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
+            "not an approved pair - bathToken"
+        );
+        _;
     }
-    RubiconMarket(RubiconMarketAddress).cancel(id);
-  }
 
-  function removeFilledTradeAmount(uint256 amt) external onlyPair {
-    outstandingAmount = outstandingAmount.sub(amt);
-  }
-
-  // function that places a bid/ask in the orderbook for a given pair
-  function placeOffer(
-    uint256 pay_amt,
-    ERC20 pay_gem,
-    uint256 buy_amt,
-    ERC20 buy_gem
-  ) external onlyApprovedStrategy returns (uint256) {
-    // Place an offer in RubiconMarket
-    // The below ensures that the order does not automatically match/become a taker trade **enforceNoAutoFills**
-    // while also ensuring that the order is placed in the sorted list
-    uint256 id = RubiconMarket(RubiconMarketAddress).offer(
-      pay_amt,
-      pay_gem,
-      buy_amt,
-      buy_gem,
-      0,
-      false
-    );
-    outstandingAmount = outstandingAmount.add(pay_amt);
-    return (id);
-  }
-
-  function underlying() external view returns (address) {
-    require(initialized);
-    return address(underlyingToken);
-  }
-
-  /// @notice returns the amount of underlying ERC20 tokens in this pool in addition to
-  ///         any tokens that may be outstanding in the Rubicon order book
-  function underlyingBalance() public view returns (uint256) {
-    require(initialized, "BathToken not initialized");
-
-    uint256 _pool = IERC20(underlyingToken).balanceOf(address(this));
-    return _pool.add(outstandingAmount);
-  }
-
-  // https://github.com/yearn/yearn-protocol/blob/develop/contracts/vaults/yVault.sol - shoutout yEarn homies
-  function deposit(uint256 _amount) external {
-    uint256 _pool = underlyingBalance();
-    uint256 _before = underlyingToken.balanceOf(address(this));
-
-    underlyingToken.transferFrom(msg.sender, address(this), _amount);
-    uint256 _after = underlyingToken.balanceOf(address(this));
-    _amount = _after.sub(_before); // Additional check for deflationary tokens
-
-    uint256 shares = 0;
-    if (totalSupply == 0) {
-      shares = _amount;
-    } else {
-      shares = (_amount.mul(totalSupply)).div(_pool);
+    modifier onlyApprovedStrategy() {
+        require(
+            BathHouse(bathHouse).isApprovedStrat(msg.sender) == true,
+            "not an approved strategy - bathToken"
+        );
+        _;
     }
-    _mint(msg.sender, shares);
-  }
 
-  // No rebalance implementation for lower fees and faster swaps
-  function withdraw(uint256 _shares) external {
-    uint256 r = (underlyingBalance().mul(_shares)).div(totalSupply);
-    _burn(msg.sender, _shares);
-
-    uint256 _fee = r.mul(feeBPS).div(10000);
-    IERC20(underlyingToken).transfer(feeTo, _fee);
-
-    underlyingToken.transfer(msg.sender, r.sub(_fee));
-  }
-
-  // This function returns filled orders to the correct liquidity pool and sends strategist rewards to the Pair
-  function rebalance(
-    address sisterBath,
-    address underlyingAsset, /* sister asset */
-    uint256 stratProportion
-  ) external onlyPair {
-    require(stratProportion > 0 && stratProportion < 50 && initialized);
-    uint256 stratReward = (
-      stratProportion.mul(IERC20(underlyingAsset).balanceOf(address(this)))
-    )
-    .div(10000);
-    IERC20(underlyingAsset).transfer(
-      sisterBath,
-      IERC20(underlyingAsset).balanceOf(address(this)).sub(stratReward)
-    );
-    IERC20(underlyingAsset).transfer(msg.sender, stratReward);
-  }
-
-  // *** Internal Functions ***
-
-  function _mint(address to, uint256 value) internal {
-    totalSupply = totalSupply.add(value);
-    balanceOf[to] = balanceOf[to].add(value);
-    emit Transfer(address(0), to, value);
-  }
-
-  function _burn(address from, uint256 value) internal {
-    balanceOf[from] = balanceOf[from].sub(value);
-    totalSupply = totalSupply.sub(value);
-    emit Transfer(from, address(0), value);
-  }
-
-  function _approve(
-    address owner,
-    address spender,
-    uint256 value
-  ) private {
-    allowance[owner][spender] = value;
-    emit Approval(owner, spender, value);
-  }
-
-  function _transfer(
-    address from,
-    address to,
-    uint256 value
-  ) private {
-    balanceOf[from] = balanceOf[from].sub(value);
-    balanceOf[to] = balanceOf[to].add(value);
-    emit Transfer(from, to, value);
-  }
-
-  function approve(address spender, uint256 value) external returns (bool) {
-    _approve(msg.sender, spender, value);
-    return true;
-  }
-
-  function transfer(address to, uint256 value) external returns (bool) {
-    _transfer(msg.sender, to, value);
-    return true;
-  }
-
-  function transferFrom(
-    address from,
-    address to,
-    uint256 value
-  ) external returns (bool) {
-    if (allowance[from][msg.sender] != uint256(-1)) {
-      allowance[from][msg.sender] = allowance[from][msg.sender].sub(value);
+    function setMarket(address newRubiconMarket) external {
+        require(msg.sender == bathHouse && initialized);
+        RubiconMarketAddress = newRubiconMarket;
     }
-    _transfer(from, to, value);
-    return true;
-  }
 
-  function permit(
-    address owner,
-    address spender,
-    uint256 value,
-    uint256 deadline,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  ) external {
-    require(deadline >= block.timestamp, "bathToken: EXPIRED");
-    bytes32 digest = keccak256(
-      abi.encodePacked(
-        "\x19\x01",
-        DOMAIN_SEPARATOR,
-        keccak256(
-          abi.encode(
-            PERMIT_TYPEHASH,
-            owner,
-            spender,
-            value,
-            nonces[owner]++,
-            deadline
-          )
+    function setBathHouse(address newBathHouse) external {
+        require(msg.sender == bathHouse && initialized);
+        bathHouse = newBathHouse;
+    }
+
+    function setFeeBPS(uint256 _feeBPS) external {
+        require(msg.sender == bathHouse && initialized);
+        feeBPS = _feeBPS;
+    }
+
+    function setFeeTo(address _feeTo) external {
+        require(msg.sender == bathHouse && initialized);
+        feeTo = _feeTo;
+    }
+
+    // Rubicon Market Functions:
+    // pass initAmt as zero if unsure
+    function cancel(uint256 id, uint256 initAmt) external onlyPair {
+        if (initAmt == 0) {
+            (uint256 pay_amt, , , ) = RubiconMarket(RubiconMarketAddress)
+            .getOffer(id);
+            outstandingAmount = outstandingAmount.sub(pay_amt);
+        } else {
+            outstandingAmount = outstandingAmount.sub(initAmt);
+        }
+        RubiconMarket(RubiconMarketAddress).cancel(id);
+    }
+
+    function removeFilledTradeAmount(uint256 amt) external onlyPair {
+        outstandingAmount = outstandingAmount.sub(amt);
+    }
+
+    // function that places a bid/ask in the orderbook for a given pair
+    function placeOffer(
+        uint256 pay_amt,
+        ERC20 pay_gem,
+        uint256 buy_amt,
+        ERC20 buy_gem
+    ) external onlyApprovedStrategy returns (uint256) {
+        // Place an offer in RubiconMarket
+        // The below ensures that the order does not automatically match/become a taker trade **enforceNoAutoFills**
+        // while also ensuring that the order is placed in the sorted list
+        uint256 id = RubiconMarket(RubiconMarketAddress).offer(
+            pay_amt,
+            pay_gem,
+            buy_amt,
+            buy_gem,
+            0,
+            false
+        );
+        outstandingAmount = outstandingAmount.add(pay_amt);
+        return (id);
+    }
+
+    function underlying() external view returns (address) {
+        require(initialized);
+        return address(underlyingToken);
+    }
+
+    /// @notice returns the amount of underlying ERC20 tokens in this pool in addition to
+    ///         any tokens that may be outstanding in the Rubicon order book
+    function underlyingBalance() public view returns (uint256) {
+        require(initialized, "BathToken not initialized");
+
+        uint256 _pool = IERC20(underlyingToken).balanceOf(address(this));
+        return _pool.add(outstandingAmount);
+    }
+
+    // https://github.com/yearn/yearn-protocol/blob/develop/contracts/vaults/yVault.sol - shoutout yEarn homies
+    function deposit(uint256 _amount) external {
+        uint256 _pool = underlyingBalance();
+        uint256 _before = underlyingToken.balanceOf(address(this));
+
+        underlyingToken.transferFrom(msg.sender, address(this), _amount);
+        uint256 _after = underlyingToken.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+
+        uint256 shares = 0;
+        if (totalSupply == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply)).div(_pool);
+        }
+        _mint(msg.sender, shares);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) external {
+        uint256 r = (underlyingBalance().mul(_shares)).div(totalSupply);
+        _burn(msg.sender, _shares);
+
+        uint256 _fee = r.mul(feeBPS).div(10000);
+        IERC20(underlyingToken).transfer(feeTo, _fee);
+
+        underlyingToken.transfer(msg.sender, r.sub(_fee));
+    }
+
+    // This function returns filled orders to the correct liquidity pool and sends strategist rewards to the Pair
+    function rebalance(
+        address sisterBath,
+        address underlyingAsset, /* sister asset */
+        uint256 stratProportion
+    ) external onlyPair {
+        require(stratProportion > 0 && stratProportion < 50 && initialized);
+        uint256 stratReward = (
+            stratProportion.mul(
+                IERC20(underlyingAsset).balanceOf(address(this))
+            )
         )
-      )
-    );
-    address recoveredAddress = ecrecover(digest, v, r, s);
-    require(
-      recoveredAddress != address(0) && recoveredAddress == owner,
-      "bathToken: INVALID_SIGNATURE"
-    );
-    _approve(owner, spender, value);
-  }
+        .div(10000);
+        IERC20(underlyingAsset).transfer(
+            sisterBath,
+            IERC20(underlyingAsset).balanceOf(address(this)).sub(stratReward)
+        );
+        IERC20(underlyingAsset).transfer(msg.sender, stratReward);
+    }
+
+    // *** Internal Functions ***
+
+    function _mint(address to, uint256 value) internal {
+        totalSupply = totalSupply.add(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burn(address from, uint256 value) internal {
+        balanceOf[from] = balanceOf[from].sub(value);
+        totalSupply = totalSupply.sub(value);
+        emit Transfer(from, address(0), value);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 value
+    ) private {
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _transfer(
+        address from,
+        address to,
+        uint256 value
+    ) private {
+        balanceOf[from] = balanceOf[from].sub(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(from, to, value);
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _approve(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool) {
+        if (allowance[from][msg.sender] != uint256(-1)) {
+            allowance[from][msg.sender] = allowance[from][msg.sender].sub(
+                value
+            );
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(deadline >= block.timestamp, "bathToken: EXPIRED");
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        PERMIT_TYPEHASH,
+                        owner,
+                        spender,
+                        value,
+                        nonces[owner]++,
+                        deadline
+                    )
+                )
+            )
+        );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "bathToken: INVALID_SIGNATURE"
+        );
+        _approve(owner, spender, value);
+    }
 }

--- a/contracts/rubiconPools/BidAskUtil.sol
+++ b/contracts/rubiconPools/BidAskUtil.sol
@@ -14,177 +14,186 @@ import "./BathHouse.sol";
 import "./BathPair.sol";
 
 contract BidAskUtil {
-  using SafeMath for uint256;
-  bool public initialized;
+    using SafeMath for uint256;
+    bool public initialized;
 
-  string public name;
+    string public name;
 
-  address public bathHouse;
+    address public bathHouse;
 
-  address public RubiconMarketAddress;
+    address public RubiconMarketAddress;
 
-  event LogTrade(uint256, ERC20, uint256, ERC20);
+    event LogTrade(uint256, ERC20, uint256, ERC20);
 
-  struct order {
-    uint256 pay_amt;
-    ERC20 pay_gem;
-    uint256 buy_amt;
-    ERC20 buy_gem;
-  }
-
-  function initialize(
-    string memory _name,
-    address _bathHouse,
-    address _rubiconMarket
-  ) external {
-    require(!initialized);
-    name = _name;
-    bathHouse = _bathHouse;
-    RubiconMarketAddress = _rubiconMarket;
-    initialized = true;
-  }
-
-  modifier onlyPairs {
-    require(
-      BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
-      "not an approved pair"
-    );
-    _;
-  }
-
-  function placePairsTrade(
-    address underlyingAsset,
-    address bathAssetAddress,
-    address underlyingQuote,
-    address bathQuoteAddress,
-    uint256 askNumerator,
-    uint256 askDenomenator,
-    uint256 bidNumerator,
-    uint256 bidDenomenator
-  ) internal {
-    // 1. Calculate new bid and ask
-    (order memory ask, order memory bid) = getNewOrders(
-      underlyingAsset,
-      underlyingQuote,
-      askNumerator,
-      askDenomenator,
-      bidNumerator,
-      bidDenomenator
-    );
-
-    // 2. place new bid and ask
-    placeTrades(
-      bathAssetAddress,
-      bathQuoteAddress,
-      ask,
-      bid,
-      underlyingAsset,
-      underlyingQuote
-    );
-  }
-
-  function getNewOrders(
-    address underlyingAsset,
-    address underlyingQuote,
-    uint256 askNumerator,
-    uint256 askDenominator,
-    uint256 bidNumerator,
-    uint256 bidDenominator
-  ) internal pure returns (order memory, order memory) {
-    ERC20 ERC20underlyingAsset = ERC20(underlyingAsset);
-    ERC20 ERC20underlyingQuote = ERC20(underlyingQuote);
-
-    order memory newAsk = order(
-      askNumerator,
-      ERC20underlyingAsset,
-      askDenominator,
-      ERC20underlyingQuote
-    );
-    order memory newBid = order(
-      (bidNumerator),
-      ERC20underlyingQuote,
-      bidDenominator,
-      ERC20underlyingAsset
-    );
-    return (newAsk, newBid);
-  }
-
-  // Calls offer (a,b,c,d, 0, false) on Rubicon Market to ensure to autofills
-  function placeTrades(
-    address bathAssetAddress,
-    address bathQuoteAddress,
-    order memory ask,
-    order memory bid,
-    address asset,
-    address quote
-  ) internal {
-    address pair = BathHouse(bathHouse).getBathPair(asset, quote);
-
-    if (
-      ask.pay_amt > 0 && ask.buy_amt > 0 && bid.buy_amt > 0 && bid.pay_amt > 0
-    ) {
-      uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
-        ask.pay_amt,
-        ask.pay_gem,
-        ask.buy_amt,
-        ask.buy_gem
-      );
-      emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
-
-      uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
-        bid.pay_amt,
-        bid.pay_gem,
-        bid.buy_amt,
-        bid.buy_gem
-      );
-      emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
-      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
-      BathPair(pair).addOutstandingPair([newAskID, ask.pay_amt, newBidID, bid.pay_amt, block.timestamp]);
-    } else if (bid.buy_amt > 0 && bid.pay_amt > 0) {
-      uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
-        bid.pay_amt,
-        bid.pay_gem,
-        bid.buy_amt,
-        bid.buy_gem
-      );
-      emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
-      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
-      BathPair(pair).addOutstandingPair([0, 0, newBidID, bid.pay_amt, block.timestamp]);
-    } else {
-      uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
-        ask.pay_amt,
-        ask.pay_gem,
-        ask.buy_amt,
-        ask.buy_gem
-      );
-      emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
-      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
-      BathPair(pair).addOutstandingPair([newAskID, ask.pay_amt, 0, 0, block.timestamp]);
+    struct order {
+        uint256 pay_amt;
+        ERC20 pay_gem;
+        uint256 buy_amt;
+        ERC20 buy_gem;
     }
-  }
 
-  function execute(
-    address underlyingAsset,
-    address bathAssetAddress,
-    address underlyingQuote,
-    address bathQuoteAddress,
-    uint256 askNumerator,
-    uint256 askDenominator,
-    uint256 bidNumerator,
-    uint256 bidDenominator
-  ) external onlyPairs {
-    // main function to chain the actions of a single strategic market making transaction (pairs trade w/ bid and ask)
+    function initialize(
+        string memory _name,
+        address _bathHouse,
+        address _rubiconMarket
+    ) external {
+        require(!initialized);
+        name = _name;
+        bathHouse = _bathHouse;
+        RubiconMarketAddress = _rubiconMarket;
+        initialized = true;
+    }
 
-    // Place pairs trade according to input
-    placePairsTrade(
-      underlyingAsset,
-      bathAssetAddress,
-      underlyingQuote,
-      bathQuoteAddress,
-      askNumerator,
-      askDenominator,
-      bidNumerator,
-      bidDenominator
-    );
-  }
+    modifier onlyPairs {
+        require(
+            BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
+            "not an approved pair"
+        );
+        _;
+    }
+
+    function placePairsTrade(
+        address underlyingAsset,
+        address bathAssetAddress,
+        address underlyingQuote,
+        address bathQuoteAddress,
+        uint256 askNumerator,
+        uint256 askDenomenator,
+        uint256 bidNumerator,
+        uint256 bidDenomenator
+    ) internal {
+        // 1. Calculate new bid and ask
+        (order memory ask, order memory bid) = getNewOrders(
+            underlyingAsset,
+            underlyingQuote,
+            askNumerator,
+            askDenomenator,
+            bidNumerator,
+            bidDenomenator
+        );
+
+        // 2. place new bid and ask
+        placeTrades(
+            bathAssetAddress,
+            bathQuoteAddress,
+            ask,
+            bid,
+            underlyingAsset,
+            underlyingQuote
+        );
+    }
+
+    function getNewOrders(
+        address underlyingAsset,
+        address underlyingQuote,
+        uint256 askNumerator,
+        uint256 askDenominator,
+        uint256 bidNumerator,
+        uint256 bidDenominator
+    ) internal pure returns (order memory, order memory) {
+        ERC20 ERC20underlyingAsset = ERC20(underlyingAsset);
+        ERC20 ERC20underlyingQuote = ERC20(underlyingQuote);
+
+        order memory newAsk = order(
+            askNumerator,
+            ERC20underlyingAsset,
+            askDenominator,
+            ERC20underlyingQuote
+        );
+        order memory newBid = order(
+            (bidNumerator),
+            ERC20underlyingQuote,
+            bidDenominator,
+            ERC20underlyingAsset
+        );
+        return (newAsk, newBid);
+    }
+
+    // Calls offer (a,b,c,d, 0, false) on Rubicon Market to ensure to autofills
+    function placeTrades(
+        address bathAssetAddress,
+        address bathQuoteAddress,
+        order memory ask,
+        order memory bid,
+        address asset,
+        address quote
+    ) internal {
+        address pair = BathHouse(bathHouse).getBathPair(asset, quote);
+
+        if (
+            ask.pay_amt > 0 &&
+            ask.buy_amt > 0 &&
+            bid.buy_amt > 0 &&
+            bid.pay_amt > 0
+        ) {
+            uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
+                ask.pay_amt,
+                ask.pay_gem,
+                ask.buy_amt,
+                ask.buy_gem
+            );
+            emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
+
+            uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
+                bid.pay_amt,
+                bid.pay_gem,
+                bid.buy_amt,
+                bid.buy_gem
+            );
+            emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
+            // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+            BathPair(pair).addOutstandingPair(
+                [newAskID, ask.pay_amt, newBidID, bid.pay_amt, block.timestamp]
+            );
+        } else if (bid.buy_amt > 0 && bid.pay_amt > 0) {
+            uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
+                bid.pay_amt,
+                bid.pay_gem,
+                bid.buy_amt,
+                bid.buy_gem
+            );
+            emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
+            // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+            BathPair(pair).addOutstandingPair(
+                [0, 0, newBidID, bid.pay_amt, block.timestamp]
+            );
+        } else {
+            uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
+                ask.pay_amt,
+                ask.pay_gem,
+                ask.buy_amt,
+                ask.buy_gem
+            );
+            emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
+            // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+            BathPair(pair).addOutstandingPair(
+                [newAskID, ask.pay_amt, 0, 0, block.timestamp]
+            );
+        }
+    }
+
+    function execute(
+        address underlyingAsset,
+        address bathAssetAddress,
+        address underlyingQuote,
+        address bathQuoteAddress,
+        uint256 askNumerator,
+        uint256 askDenominator,
+        uint256 bidNumerator,
+        uint256 bidDenominator
+    ) external onlyPairs {
+        // main function to chain the actions of a single strategic market making transaction (pairs trade w/ bid and ask)
+
+        // Place pairs trade according to input
+        placePairsTrade(
+            underlyingAsset,
+            bathAssetAddress,
+            underlyingQuote,
+            bathQuoteAddress,
+            askNumerator,
+            askDenominator,
+            bidNumerator,
+            bidDenominator
+        );
+    }
 }

--- a/contracts/rubiconPools/BidAskUtil.sol
+++ b/contracts/rubiconPools/BidAskUtil.sol
@@ -14,181 +14,177 @@ import "./BathHouse.sol";
 import "./BathPair.sol";
 
 contract BidAskUtil {
-    using SafeMath for uint256;
-    bool public initialized;
+  using SafeMath for uint256;
+  bool public initialized;
 
-    string public name;
+  string public name;
 
-    address public bathHouse;
+  address public bathHouse;
 
-    address public RubiconMarketAddress;
+  address public RubiconMarketAddress;
 
-    event LogTrade(uint256, ERC20, uint256, ERC20);
+  event LogTrade(uint256, ERC20, uint256, ERC20);
 
-    struct order {
-        uint256 pay_amt;
-        ERC20 pay_gem;
-        uint256 buy_amt;
-        ERC20 buy_gem;
+  struct order {
+    uint256 pay_amt;
+    ERC20 pay_gem;
+    uint256 buy_amt;
+    ERC20 buy_gem;
+  }
+
+  function initialize(
+    string memory _name,
+    address _bathHouse,
+    address _rubiconMarket
+  ) external {
+    require(!initialized);
+    name = _name;
+    bathHouse = _bathHouse;
+    RubiconMarketAddress = _rubiconMarket;
+    initialized = true;
+  }
+
+  modifier onlyPairs {
+    require(
+      BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
+      "not an approved pair"
+    );
+    _;
+  }
+
+  function placePairsTrade(
+    address underlyingAsset,
+    address bathAssetAddress,
+    address underlyingQuote,
+    address bathQuoteAddress,
+    uint256 askNumerator,
+    uint256 askDenomenator,
+    uint256 bidNumerator,
+    uint256 bidDenomenator
+  ) internal {
+    // 1. Calculate new bid and ask
+    (order memory ask, order memory bid) = getNewOrders(
+      underlyingAsset,
+      underlyingQuote,
+      askNumerator,
+      askDenomenator,
+      bidNumerator,
+      bidDenomenator
+    );
+
+    // 2. place new bid and ask
+    placeTrades(
+      bathAssetAddress,
+      bathQuoteAddress,
+      ask,
+      bid,
+      underlyingAsset,
+      underlyingQuote
+    );
+  }
+
+  function getNewOrders(
+    address underlyingAsset,
+    address underlyingQuote,
+    uint256 askNumerator,
+    uint256 askDenominator,
+    uint256 bidNumerator,
+    uint256 bidDenominator
+  ) internal pure returns (order memory, order memory) {
+    ERC20 ERC20underlyingAsset = ERC20(underlyingAsset);
+    ERC20 ERC20underlyingQuote = ERC20(underlyingQuote);
+
+    order memory newAsk = order(
+      askNumerator,
+      ERC20underlyingAsset,
+      askDenominator,
+      ERC20underlyingQuote
+    );
+    order memory newBid = order(
+      (bidNumerator),
+      ERC20underlyingQuote,
+      bidDenominator,
+      ERC20underlyingAsset
+    );
+    return (newAsk, newBid);
+  }
+
+  // Calls offer (a,b,c,d, 0, false) on Rubicon Market to ensure to autofills
+  function placeTrades(
+    address bathAssetAddress,
+    address bathQuoteAddress,
+    order memory ask,
+    order memory bid,
+    address asset,
+    address quote
+  ) internal {
+    address pair = BathHouse(bathHouse).getBathPair(asset, quote);
+
+    if (
+      ask.pay_amt > 0 && ask.buy_amt > 0 && bid.buy_amt > 0 && bid.pay_amt > 0
+    ) {
+      uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
+        ask.pay_amt,
+        ask.pay_gem,
+        ask.buy_amt,
+        ask.buy_gem
+      );
+      emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
+
+      uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
+        bid.pay_amt,
+        bid.pay_gem,
+        bid.buy_amt,
+        bid.buy_gem
+      );
+      emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
+      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+      BathPair(pair).addOutstandingPair([newAskID, ask.pay_amt, newBidID, bid.pay_amt, block.timestamp]);
+    } else if (bid.buy_amt > 0 && bid.pay_amt > 0) {
+      uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
+        bid.pay_amt,
+        bid.pay_gem,
+        bid.buy_amt,
+        bid.buy_gem
+      );
+      emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
+      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+      BathPair(pair).addOutstandingPair([0, 0, newBidID, bid.pay_amt, block.timestamp]);
+    } else {
+      uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
+        ask.pay_amt,
+        ask.pay_gem,
+        ask.buy_amt,
+        ask.buy_gem
+      );
+      emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
+      // [askID, ask.pay_amt, bidID, bid.pay_amt, timestamp]
+      BathPair(pair).addOutstandingPair([newAskID, ask.pay_amt, 0, 0, block.timestamp]);
     }
+  }
 
-    function initialize(
-        string memory _name,
-        address _bathHouse,
-        address _rubiconMarket
-    ) external {
-        require(!initialized);
-        name = _name;
-        bathHouse = _bathHouse;
-        RubiconMarketAddress = _rubiconMarket;
-        initialized = true;
-    }
+  function execute(
+    address underlyingAsset,
+    address bathAssetAddress,
+    address underlyingQuote,
+    address bathQuoteAddress,
+    uint256 askNumerator,
+    uint256 askDenominator,
+    uint256 bidNumerator,
+    uint256 bidDenominator
+  ) external onlyPairs {
+    // main function to chain the actions of a single strategic market making transaction (pairs trade w/ bid and ask)
 
-    modifier onlyPairs {
-        require(
-            BathHouse(bathHouse).isApprovedPair(msg.sender) == true,
-            "not an approved pair"
-        );
-        _;
-    }
-
-    function placePairsTrade(
-        address underlyingAsset,
-        address bathAssetAddress,
-        address underlyingQuote,
-        address bathQuoteAddress,
-        uint256 askNumerator,
-        uint256 askDenomenator,
-        uint256 bidNumerator,
-        uint256 bidDenomenator
-    ) internal {
-        // 1. Calculate new bid and ask
-        (order memory ask, order memory bid) = getNewOrders(
-            underlyingAsset,
-            underlyingQuote,
-            askNumerator,
-            askDenomenator,
-            bidNumerator,
-            bidDenomenator
-        );
-
-        // 2. place new bid and ask
-        placeTrades(
-            bathAssetAddress,
-            bathQuoteAddress,
-            ask,
-            bid,
-            underlyingAsset,
-            underlyingQuote
-        );
-    }
-
-    function getNewOrders(
-        address underlyingAsset,
-        address underlyingQuote,
-        uint256 askNumerator,
-        uint256 askDenominator,
-        uint256 bidNumerator,
-        uint256 bidDenominator
-    ) internal pure returns (order memory, order memory) {
-        ERC20 ERC20underlyingAsset = ERC20(underlyingAsset);
-        ERC20 ERC20underlyingQuote = ERC20(underlyingQuote);
-
-        order memory newAsk = order(
-            askNumerator,
-            ERC20underlyingAsset,
-            askDenominator,
-            ERC20underlyingQuote
-        );
-        order memory newBid = order(
-            (bidNumerator),
-            ERC20underlyingQuote,
-            bidDenominator,
-            ERC20underlyingAsset
-        );
-        return (newAsk, newBid);
-    }
-
-    // Calls offer (a,b,c,d, 0, false) on Rubicon Market to ensure to autofills
-    function placeTrades(
-        address bathAssetAddress,
-        address bathQuoteAddress,
-        order memory ask,
-        order memory bid,
-        address asset,
-        address quote
-    ) internal {
-        address pair = BathHouse(bathHouse).getBathPair(asset, quote);
-
-        if (
-            ask.pay_amt > 0 &&
-            ask.buy_amt > 0 &&
-            bid.buy_amt > 0 &&
-            bid.pay_amt > 0
-        ) {
-            uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
-                ask.pay_amt,
-                ask.pay_gem,
-                ask.buy_amt,
-                ask.buy_gem
-            );
-            emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
-
-            uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
-                bid.pay_amt,
-                bid.pay_gem,
-                bid.buy_amt,
-                bid.buy_gem
-            );
-            emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
-
-            BathPair(pair).addOutstandingPair(
-                [newAskID, newBidID, block.timestamp]
-            );
-        } else if (bid.buy_amt > 0 && bid.pay_amt > 0) {
-            uint256 newBidID = BathToken(bathQuoteAddress).placeOffer(
-                bid.pay_amt,
-                bid.pay_gem,
-                bid.buy_amt,
-                bid.buy_gem
-            );
-            emit LogTrade(bid.pay_amt, bid.pay_gem, bid.buy_amt, bid.buy_gem);
-
-            BathPair(pair).addOutstandingPair([0, newBidID, block.timestamp]);
-        } else {
-            uint256 newAskID = BathToken(bathAssetAddress).placeOffer(
-                ask.pay_amt,
-                ask.pay_gem,
-                ask.buy_amt,
-                ask.buy_gem
-            );
-            emit LogTrade(ask.pay_amt, ask.pay_gem, ask.buy_amt, ask.buy_gem);
-            BathPair(pair).addOutstandingPair([newAskID, 0, block.timestamp]);
-        }
-    }
-
-    function execute(
-        address underlyingAsset,
-        address bathAssetAddress,
-        address underlyingQuote,
-        address bathQuoteAddress,
-        uint256 askNumerator,
-        uint256 askDenominator,
-        uint256 bidNumerator,
-        uint256 bidDenominator
-    ) external onlyPairs {
-        // main function to chain the actions of a single strategic market making transaction (pairs trade w/ bid and ask)
-
-        // Place pairs trade according to input
-        placePairsTrade(
-            underlyingAsset,
-            bathAssetAddress,
-            underlyingQuote,
-            bathQuoteAddress,
-            askNumerator,
-            askDenominator,
-            bidNumerator,
-            bidDenominator
-        );
-    }
+    // Place pairs trade according to input
+    placePairsTrade(
+      underlyingAsset,
+      bathAssetAddress,
+      underlyingQuote,
+      bathQuoteAddress,
+      askNumerator,
+      askDenominator,
+      bidNumerator,
+      bidDenominator
+    );
+  }
 }

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -301,7 +301,8 @@ contract("Rubicon Exchange and Pools Test", async function (accounts) {
       // Idea here is that the start of the local search rolls over after indexs 4-6 are checked in seconds call
       // assert.equal(await bathPairInstance.start().toString(), "0");
     });
-
+    // it("bathTokens are correctly loggin outstandingAmount", async function () {
+    // });
     it("Partial fill is correctly cancelled and replaced", async function () {
       await bathPairInstance.bathScrub();
 

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -301,8 +301,30 @@ contract("Rubicon Exchange and Pools Test", async function (accounts) {
       // Idea here is that the start of the local search rolls over after indexs 4-6 are checked in seconds call
       // assert.equal(await bathPairInstance.start().toString(), "0");
     });
-    // it("bathTokens are correctly loggin outstandingAmount", async function () {
-    // });
+    it("bathTokens are correctly loggin outstandingAmount", async function () {
+      let target = 6;
+      for (let index = 0; index < target; index++) {
+        await bathPairInstance.executeStrategy(
+          strategyInstance.address,
+          askNumerator,
+          askDenominator,
+          bidNumerator,
+          bidDenominator
+        );
+      }
+      helper.advanceTimeAndBlock(100);
+      await bathPairInstance.bathScrub();
+      await bathPairInstance.bathScrub();
+      await bathPairInstance.bathScrub();
+      await bathPairInstance.bathScrub();
+      await bathPairInstance.bathScrub();
+      await bathPairInstance.bathScrub();
+
+      logIndented("bathAsset amount", (await bathAssetInstance.outstandingAmount()).toString());
+      logIndented("bathquote amount", web3.utils.fromWei((await bathQuoteInstance.outstandingAmount()).toString()));
+      // assert.equal(await bathAssetInstance().outstandingAmount(), "0");
+
+    });
     it("Partial fill is correctly cancelled and replaced", async function () {
       await bathPairInstance.bathScrub();
 

--- a/test/3_pool_test.js
+++ b/test/3_pool_test.js
@@ -320,10 +320,14 @@ contract("Rubicon Exchange and Pools Test", async function (accounts) {
       await bathPairInstance.bathScrub();
       await bathPairInstance.bathScrub();
 
-      logIndented("bathAsset amount", (await bathAssetInstance.outstandingAmount()).toString());
-      logIndented("bathquote amount", web3.utils.fromWei((await bathQuoteInstance.outstandingAmount()).toString()));
-      // assert.equal(await bathAssetInstance().outstandingAmount(), "0");
-
+      assert.equal(
+        (await bathAssetInstance.outstandingAmount()).toString(),
+        "0"
+      );
+      assert.equal(
+        (await bathQuoteInstance.outstandingAmount()).toString(),
+        "0"
+      );
     });
     it("Partial fill is correctly cancelled and replaced", async function () {
       await bathPairInstance.bathScrub();


### PR DESCRIPTION
This PR brings an improvement to the Rubicon Pools system in which BathTokens now account for all outstanding liquidity that is being deployed in the order book for yield. This ensures that each liquidity pool properly calculates its underlying balance. 

More importantly, this PR also brings yet another gas optimization to `bathScrub`. This new release candidate version is further optimized and now allows strategists to be compensated proportionally to the wei. Before, strategists were simply incentivized to earn complete order "fills" but are now compensated some percentage of the yield generated from Pools orders they place that fill. Better strategist rewards and more accurate liquidity pool accounting - huzzah!